### PR TITLE
Implement Normalized Escape Iteration

### DIFF
--- a/examples/mandelbrot_render/default_params.json
+++ b/examples/mandelbrot_render/default_params.json
@@ -8,6 +8,7 @@
         0.0
     ],
     "domain_real": 3.0,
-    "escape_radius_squared": 5.0,
-    "max_iter_count": 750
+    "escape_radius_squared": 100.0,
+    "max_iter_count": 500,
+    "refinement_count": 5
 }

--- a/examples/mandelbrot_search/default_params.json
+++ b/examples/mandelbrot_search/default_params.json
@@ -5,6 +5,7 @@
     ],
     "render_escape_radius_squared": 4.0,
     "render_max_iter_count": 550,
+    "render_refinement_count": 5,
     "center": [
         -0.2,
         0.0
@@ -15,6 +16,6 @@
     ],
     "search_escape_radius_squared": 4.0,
     "search_max_iter_count": 550,
-    "max_num_renders": 16,
+    "max_num_renders": 8,
     "max_search_count": 10000
 }


### PR DESCRIPTION
## Summary:

Updates the core sequence iterator so that it can now (optionally) support a refinement count, which will produce smooth interpolants between two successive iteration counts. The result is the ability to produce much higher quality images at relatively lower iteration counts, and higher-quality renders in general.

As part of that work, I refactored the mandelbrot sequence logic into a class to make the code a bit easier to work with.

## Examples:

Here is a sample low-resolution render using the traditional integer-based count. This is implemented by setting the refinement count to zero:
```json
{
    "image_resolution": [
        600,
        400
    ],
    "center": [
        -0.5,
        -0.62
    ],
    "domain_real": 0.5,
    "escape_radius_squared": 10,
    "max_iter_count": 45,
    "refinement_count": 0
}
```
![render](https://github.com/MatthewPeterKelly/fractal-renderer/assets/8137529/73b65b86-0e24-419a-9109-05f98f2ef6b2)


Here is the same exact render, this time setting the refinement count to 5, providing smooth interpolation between the integer escape counts:
```json
{
    "image_resolution": [
        600,
        400
    ],
    "center": [
        -0.5,
        -0.62
    ],
    "domain_real": 0.5,
    "escape_radius_squared": 10,
    "max_iter_count": 45,
    "refinement_count": 
}
```
![render](https://github.com/MatthewPeterKelly/fractal-renderer/assets/8137529/dbe1f00c-ca40-441b-aaf7-e1eee112e613)

There is still some work to be done cleaning up these color maps, but that can be in a follow-up PR.