### PR TITLE
Remove unused `default()` methods

### DIFF
--- a/src/ddp_utils.rs
+++ b/src/ddp_utils.rs
@@ -24,18 +24,6 @@ pub struct DrivenDampedPendulumParams {
     pub periodic_state_error_tolerance: f64,
 }
 
-impl Default for DrivenDampedPendulumParams {
-    fn default() -> DrivenDampedPendulumParams {
-        DrivenDampedPendulumParams {
-            image_specification: render::ImageSpecification::default(),
-            time_phase: TimePhaseSpecification::Snapshot(0.0),
-            n_max_period: (100),
-            n_steps_per_period: (10),
-            periodic_state_error_tolerance: (1e-4),
-        }
-    }
-}
-
 /**
  * Based on implementation from:
  * https://www.dropbox.com/home/mpk/Documents/Random_Projects/Driven_Damped_Pendulum/Version%202?preview=Driven_Damped_Pendulum.m

--- a/src/mandelbrot_core.rs
+++ b/src/mandelbrot_core.rs
@@ -19,18 +19,6 @@ pub struct MandelbrotParams {
     pub histogram_bin_count: usize,
 }
 
-impl Default for MandelbrotParams {
-    fn default() -> MandelbrotParams {
-        MandelbrotParams {
-            image_specification: render::ImageSpecification::default(),
-            escape_radius_squared: (4.0),
-            max_iter_count: (550),
-            refinement_count: (5),
-            histogram_bin_count: (512),
-        }
-    }
-}
-
 /**
  * @param dimensions: local "width" and "height" of the retangle in imaginary space
  * @param center: location of the center of that rectangle

--- a/src/mandelbrot_search.rs
+++ b/src/mandelbrot_search.rs
@@ -39,29 +39,6 @@ pub struct MandelbrotSearchParams {
     pub max_search_count: i32,
 }
 
-impl Default for MandelbrotSearchParams {
-    fn default() -> MandelbrotSearchParams {
-        MandelbrotSearchParams {
-            // Parameters for each individual render:
-            render_image_resolution: nalgebra::Vector2::<u32>::new(1920, 1080),
-            render_escape_radius_squared: (4.0),
-            render_max_iter_count: (550),
-            render_refinement_count: (5),
-            render_view_scale_real: (0.15),
-            render_histogram_bin_count: (512),
-
-            center: nalgebra::Vector2::<f64>::new(-0.2, 0.0),
-            view_scale: nalgebra::Vector2::<f64>::new(3.0, 2.0),
-            search_escape_radius_squared: (4.0),
-            search_max_iter_count: (550),
-            query_resolution: nalgebra::Vector2::<u32>::new(16, 9),
-
-            max_num_renders: (16),
-            max_search_count: (10_000),
-        }
-    }
-}
-
 pub struct QueryResult {
     pub value: f64,
     pub point: nalgebra::Vector2<f64>,

--- a/src/render.rs
+++ b/src/render.rs
@@ -20,16 +20,6 @@ impl ImageSpecification {
     }
 }
 
-impl Default for ImageSpecification {
-    fn default() -> ImageSpecification {
-        ImageSpecification {
-            resolution: nalgebra::Vector2::<u32>::new(400, 300),
-            center: nalgebra::Vector2::<f64>::new(0.0, 0.0),
-            width: 1.0,
-        }
-    }
-}
-
 /**
  * Allows the user to specify only the resolution of the image and how much "extra space" to leave
  * around the fractal (subject) in the image. The real coordinates are derived automatically from
@@ -65,15 +55,6 @@ impl FitImage {
             resolution: self.resolution,
             center: *center,
             width: self.padding_scale * selected_width,
-        }
-    }
-}
-
-impl Default for FitImage {
-    fn default() -> FitImage {
-        FitImage {
-            resolution: nalgebra::Vector2::<u32>::new(400, 300),
-            padding_scale: 1.05,
         }
     }
 }


### PR DESCRIPTION
They were everywhere!

Follow-up to https://github.com/MatthewPeterKelly/fractal-renderer/pull/50, where I realized that these were not needed.