### PR TITLE
Add color map core library

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ cargo run --release -- render .\examples\serpinsky\triangle.json
 cargo run --release -- explore .\examples\mandelbrot\default.json
 ```
 
+```
+cargo run color-swatch -- examples\color_swatch\rainbow.json
+```
+
 ## Autoformatting:
 
 ### Rust Code:

--- a/examples/color_swatch/black_blue_white.json
+++ b/examples/color_swatch/black_blue_white.json
@@ -1,0 +1,19 @@
+{
+  "swatch_resolution": [1920, 100],
+  "border_padding": 50,
+  "border_color_rgb": [0, 0, 0],
+  "keyframes": [
+    {
+      "query": 0.0,
+      "rgb_raw": [0, 0, 0]
+    },
+    {
+      "query": 0.7,
+      "rgb_raw": [0, 0, 255]
+    },
+    {
+      "query": 1.0,
+      "rgb_raw": [255, 255, 255]
+    }
+  ]
+}

--- a/examples/color_swatch/rainbow.json
+++ b/examples/color_swatch/rainbow.json
@@ -1,0 +1,35 @@
+{
+  "swatch_resolution": [1920, 100],
+  "border_padding": 50,
+  "border_color_rgb": [0, 0, 0],
+  "keyframes": [
+    {
+      "query": 0.0,
+      "rgb_raw": [255, 0, 0]
+    },
+    {
+      "query": 0.17,
+      "rgb_raw": [255, 127, 0]
+    },
+    {
+      "query": 0.33,
+      "rgb_raw": [255, 255, 0]
+    },
+    {
+      "query": 0.5,
+      "rgb_raw": [0, 255, 0]
+    },
+    {
+      "query": 0.67,
+      "rgb_raw": [0, 0, 255]
+    },
+    {
+      "query": 0.83,
+      "rgb_raw": [75, 0, 130]
+    },
+    {
+      "query": 1.0,
+      "rgb_raw": [143, 0, 255]
+    }
+  ]
+}

--- a/examples/color_swatch/red_green_blue.json
+++ b/examples/color_swatch/red_green_blue.json
@@ -1,0 +1,19 @@
+{
+  "swatch_resolution": [1920, 100],
+  "border_padding": 50,
+  "border_color_rgb": [0, 0, 0],
+  "keyframes": [
+    {
+      "query": 0.0,
+      "rgb_raw": [255, 0, 0]
+    },
+    {
+      "query": 0.5,
+      "rgb_raw": [0, 255, 0]
+    },
+    {
+      "query": 1.0,
+      "rgb_raw": [0, 0, 255]
+    }
+  ]
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -11,6 +11,7 @@ pub struct FractalRendererArgs {
 pub enum CommandsEnum {
     Render(ParameterFilePath),
     Explore(ParameterFilePath),
+    ColorSwatch(ParameterFilePath),
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/color_swatch.rs
+++ b/src/cli/color_swatch.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+
+use crate::core::{
+    color_map::{ColorMapKeyFrame, PiecewiseLinearColorMap},
+    file_io::{serialize_to_json_or_panic, FilePrefix},
+    image_utils::write_rgb_image_to_file_or_panic,
+};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ColorSwatchParams {
+    pub swatch_resolution: (u32, u32),
+    pub border_padding: u32,
+    pub border_color_rgb: [u8; 3],
+    pub keyframes: Vec<ColorMapKeyFrame>,
+}
+
+/**
+ * Generates a "color swatch" that makes it easier to visualize color maps.
+ * -- user spacing, with no interpolation
+ * -- user spacing, with linear interpolation
+ * -- uniform spacing, with no interpolation
+ * -- uniform spacing, with linear interpolation
+ */
+pub fn generate_color_swatch(params_path: &str, file_prefix: FilePrefix) {
+    let params: ColorSwatchParams = serde_json::from_str(
+        &std::fs::read_to_string(params_path).expect("Unable to read param file"),
+    )
+    .unwrap();
+
+    serialize_to_json_or_panic(file_prefix.full_path_with_suffix(".json"), &params);
+
+    // Save the image to a file, deducing the type from the file name
+    // Create a new ImgBuf to store the render in memory (and eventually write it to a file).
+    let mut imgbuf = {
+        let total_width = 2 * params.border_padding + params.swatch_resolution.0;
+        let total_height =
+            4 * (params.border_padding + params.swatch_resolution.1) + params.border_padding;
+        image::ImageBuffer::new(total_width, total_height)
+    };
+
+    let user_colormap = PiecewiseLinearColorMap::new(params.keyframes);
+    let uniform_color_map = user_colormap.with_uniform_spacing();
+
+    let x_offset = params.border_padding;
+    let mut y_offset = params.border_padding;
+    let scale = 1.0 / ((params.swatch_resolution.0 * params.swatch_resolution.1) as f32);
+
+    for color_map in [user_colormap, uniform_color_map] {
+        for clamp_to_nearest in [true, false] {
+            for x_idx in x_offset..(x_offset + params.swatch_resolution.0) {
+                for y_idx in y_offset..(y_offset + params.swatch_resolution.1) {
+                    let linear_index = x_idx * params.swatch_resolution.1 + y_idx;
+                    *imgbuf.get_pixel_mut(x_idx, y_idx) = image::Rgb(
+                        color_map.compute(scale * (linear_index as f32), clamp_to_nearest),
+                    );
+                }
+            }
+            y_offset += params.swatch_resolution.1 + params.border_padding;
+        }
+    }
+
+    write_rgb_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), &imgbuf);
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,4 @@
 pub mod args;
+pub mod color_swatch;
 pub mod explore;
 pub mod render;

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -1,0 +1,157 @@
+use iter_num_tools::lin_space;
+use serde::{Deserialize, Serialize};
+
+/**
+ * Represents a single "keyframe" of the color map, pairing a
+ * "query" with the color that should be produced at that query point.
+ */
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ColorMapKeyFrame {
+    pub query: f32,       // specify location of this color within the map; on [0,1]
+    pub rgb_raw: [u8; 3], // [R, G, B]
+}
+
+/**
+ * Simple implementation of a "piecewise linear" color map, where the colors
+ * are represented by simple linear interpolation in RGB color space. This is
+ * not "strictly correct" from a color standpoint, but it works well enough in
+ * practice. For details see:
+ * - https://github.com/MatthewPeterKelly/fractal-renderer/pull/71
+ * - https://docs.rs/palette/latest/palette/
+ */
+pub struct PiecewiseLinearColorMap {
+    keyframes: Vec<ColorMapKeyFrame>,
+}
+
+impl PiecewiseLinearColorMap {
+    /**
+     * Create a color map from a vector of keyframes. The queries must be
+     * monotonically increasing, and the first keyframe query must be zero
+     * and the last keyframe query must be one. Colors are specified in RGB
+     * space as `u8` values on [0,255].
+     */
+    pub fn new(keyframes: Vec<ColorMapKeyFrame>) -> PiecewiseLinearColorMap {
+        if keyframes.is_empty() {
+            println!("ERROR:  keyframes are empty!");
+            panic!();
+        }
+
+        if keyframes.first().unwrap().query != 0.0 {
+            println!("ERROR:  initial keyframe query point must be 0.0!");
+            panic!();
+        }
+        if keyframes.last().unwrap().query != 1.0 {
+            println!("ERROR:  final keyframe query point must be 1.0!");
+            panic!();
+        }
+
+        for i in 0..(keyframes.len() - 1) {
+            if keyframes[i].query >= keyframes[i + 1].query {
+                println!("ERROR:  keyframes should be monotonic, but are not!");
+                panic!();
+            }
+        }
+        PiecewiseLinearColorMap { keyframes }
+    }
+
+    /**
+     * Create a new color map with the same keyframe RGB values, but replace the
+     * query values with a uniformly spaced set of queries. This is largely used
+     * for visualizing the "color swatch".
+     */
+    pub fn with_uniform_spacing(&self) -> PiecewiseLinearColorMap {
+        let queries = lin_space(0.0..=1.0, self.keyframes.len());
+        let mut keyframes: Vec<ColorMapKeyFrame> = Vec::new();
+        for (old_keyframe, query) in self.keyframes.iter().zip(queries) {
+            keyframes.push(ColorMapKeyFrame {
+                query,
+                rgb_raw: old_keyframe.rgb_raw,
+            });
+        }
+        PiecewiseLinearColorMap::new(keyframes)
+    }
+
+    /**
+     * Evaluates the color map, modestly efficient for small numbers of
+     * keyframes. Any query outside of [0,1] will be clamped.
+     */
+    pub fn compute(&self, query: f32, clamp_to_nearest: bool) -> [u8; 3] {
+        if query <= 0.0f32 {
+            self.keyframes.first().unwrap().rgb_raw
+        } else if query >= 1.0f32 {
+            self.keyframes.last().unwrap().rgb_raw
+        } else {
+            let (i, j) = self.linear_index_search(query);
+            let mut alpha = (query - self.keyframes[i].query)
+                / (self.keyframes[j].query - self.keyframes[i].query);
+            if clamp_to_nearest {
+                alpha = PiecewiseLinearColorMap::clamp_alpha_nearest(alpha);
+            }
+            Self::interpolate(
+                &self.keyframes[i].rgb_raw,
+                &self.keyframes[j].rgb_raw,
+                alpha,
+            )
+        }
+    }
+
+    /**
+     * Simple linear search, starting from the middle segment, to figure out
+     * which segment to evaluate. We could probably be faster by caching the most
+     * recent index solution, but that adds complexity and state, which are probably
+     * not worth it, given that the plan is to pre-compute the entire color map
+     * before rendering the fractal.
+     */
+    fn linear_index_search(&self, query: f32) -> (usize, usize) {
+        let mut idx_low = self.keyframes.len() / 2;
+
+        // hard limit on upper iteration, to catch bugs
+        for _ in 0..self.keyframes.len() {
+            if query < self.keyframes[idx_low].query {
+                idx_low -= 1;
+                continue;
+            }
+            if query >= self.keyframes[idx_low + 1].query {
+                idx_low += 1;
+                continue;
+            }
+            // [low <= query < upp]  --> success!
+            return (idx_low, idx_low + 1);
+        }
+
+        println!("ERROR:  Linear keyframe search failed!");
+        panic!();
+    }
+
+    /**
+     * Really simple color interpolation.
+     * See the Palette crate for a lecture about a better way to do it:
+     * https://docs.rs/palette/latest/palette/rgb/index.html
+     *
+     * I've got a version using that hacked together on a branch here:
+     * https://github.com/MatthewPeterKelly/fractal-renderer/pull/71
+     *
+     * But this simple implementation works nicely for now.
+     */
+    fn interpolate(low: &[u8; 3], upp: &[u8; 3], alpha: f32) -> [u8; 3] {
+        let beta = 1.0 - alpha;
+        [
+            ((low[0] as f32) * beta + (upp[0] as f32) * alpha) as u8,
+            ((low[1] as f32) * beta + (upp[1] as f32) * alpha) as u8,
+            ((low[2] as f32) * beta + (upp[2] as f32) * alpha) as u8,
+        ]
+    }
+
+    /**
+     * This is a bit of a hack, but it makes it easy to implement the
+     * color swatch utility. And, who knows, perhaps it would be useful
+     * to render a fractal with sharp color bands someday.
+     */
+    fn clamp_alpha_nearest(alpha: f32) -> f32 {
+        if alpha < 0.5 {
+            0.0
+        } else {
+            1.0
+        }
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod chaos_game;
+pub mod color_map;
 pub mod file_io;
 pub mod histogram;
 pub mod image_utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use core::file_io::{
 
 use clap::Parser;
 use cli::args::{CommandsEnum, FractalRendererArgs, ParameterFilePath};
+use cli::color_swatch::generate_color_swatch;
 use cli::explore::explore_fractal;
 use cli::render::render_fractal;
 use fractals::common::FractalParams;
@@ -47,6 +48,12 @@ fn main() {
             .unwrap();
         }
 
+        Some(CommandsEnum::ColorSwatch(params)) => {
+            generate_color_swatch(
+                &params.params_path,
+                build_file_prefix(params, "color_swatch"),
+            );
+        }
         None => {
             println!("Default command (nothing specified!)");
         }


### PR DESCRIPTION
Adds a color map class that can import a color map from JSON, along with a utility that can visualize the color map. Here is an example of the "rainbow" color swatch:
![rainbow](https://github.com/user-attachments/assets/201c7cdc-4e9a-43bb-b278-58098abdcc55)
