### PR TITLE
Major clean-up for file management

### DIFF
--- a/examples/serpinsky/hexagon.json
+++ b/examples/serpinsky/hexagon.json
@@ -7,7 +7,7 @@
     "sample_count": 50000000,
     "subpixel_antialiasing": 2,
     "background_color_rgba": [0, 0, 0, 255],
-    "vertex_colors": [
+    "vertex_colors_rgba": [
       [255, 0, 0, 255],
       [0, 255, 0, 255],
       [0, 0, 255, 255],

--- a/examples/serpinsky/pentagon.json
+++ b/examples/serpinsky/pentagon.json
@@ -7,7 +7,7 @@
     "sample_count": 50000000,
     "subpixel_antialiasing": 2,
     "background_color_rgba": [0, 0, 0, 255],
-    "vertex_colors": [
+    "vertex_colors_rgba": [
       [255, 0, 0, 255],
       [0, 255, 0, 255],
       [0, 0, 255, 255],

--- a/examples/serpinsky/triangle.json
+++ b/examples/serpinsky/triangle.json
@@ -7,7 +7,7 @@
     "sample_count": 10000000,
     "subpixel_antialiasing": 2,
     "background_color_rgba": [0, 0, 0, 255],
-    "vertex_colors": [
+    "vertex_colors_rgba": [
       [255, 0, 0, 255],
       [0, 255, 0, 255],
       [0, 0, 255, 255]

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -6,28 +6,26 @@ use crate::fractals::{
 
 use crate::core::file_io::FilePrefix;
 
-pub fn render_fractal<F>(
+pub fn render_fractal(
     params: &FractalParams,
-    file_prefix: F,
-) -> Result<(), Box<dyn std::error::Error>>
-where
-    F: Fn(&str) -> FilePrefix,
-{
+    mut file_prefix: FilePrefix,
+) -> Result<(), Box<dyn std::error::Error>> {
     match params {
         FractalParams::Mandelbrot(inner_params) => {
-            render_mandelbrot_set(inner_params, &file_prefix("mendelbrot"))
+            file_prefix.create_and_step_into_sub_directory("mandelbrot");
+            render_mandelbrot_set(inner_params, file_prefix)
         }
         FractalParams::DrivenDampedPendulum(inner_params) => {
-            render_driven_damped_pendulum_attractor(
-                inner_params,
-                &file_prefix("driven_damped_pendulum"),
-            )
+            file_prefix.create_and_step_into_sub_directory("driven_damped_pendulum");
+            render_driven_damped_pendulum_attractor(inner_params, file_prefix)
         }
         FractalParams::BarnsleyFern(inner_params) => {
-            render_barnsley_fern(inner_params, &file_prefix("barnsley_fern"))
+            file_prefix.create_and_step_into_sub_directory("barnsley_fern");
+            render_barnsley_fern(inner_params, file_prefix)
         }
         FractalParams::Serpinsky(inner_params) => {
-            render_serpinsky(inner_params, &file_prefix("serpinsky"))
+            file_prefix.create_and_step_into_sub_directory("serpinsky");
+            render_serpinsky(inner_params, file_prefix)
         }
     }
 }

--- a/src/core/file_io.rs
+++ b/src/core/file_io.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
 
+use serde::Serialize;
+use std::fmt::Debug;
+
 pub fn extract_base_name(path: &str) -> &str {
     std::path::Path::new(path)
         .file_stem() // Get the base name component of the path
@@ -8,15 +11,13 @@ pub fn extract_base_name(path: &str) -> &str {
 }
 
 pub fn build_output_path_with_date_time(
-    params_path: &str,
     project: &str,
     datetime: &Option<String>,
 ) -> std::path::PathBuf {
-    let mut dirs = vec!["out", project, extract_base_name(params_path)];
+    let mut dirs = vec!["out", project];
     if let Some(inner_datetime_str) = datetime {
         dirs.push(inner_datetime_str);
     }
-
     let directory_path: PathBuf = dirs.iter().collect();
     std::fs::create_dir_all(&directory_path).unwrap();
     directory_path
@@ -44,24 +45,44 @@ pub fn maybe_date_time_string(enable: bool) -> Option<String> {
     }
 }
 
+pub fn serialize_to_json_or_panic<T>(filename: std::path::PathBuf, data: &T)
+where
+    T: Serialize + Debug,
+{
+    let serialized_data = serde_json::to_string(data)
+        .unwrap_or_else(|_| panic!("ERROR:  Unable to serialize data: {:?}", data));
+    std::fs::write(&filename, serialized_data)
+        .unwrap_or_else(|_| panic!("ERROR:  Unable to write file: {:?}", filename));
+}
+
 /**
  * Store a path and prefix together, making it easily to quickly generate
  * a collection of files with the same prefix, but separate suffixes.
  */
+#[derive(Clone, Debug)]
 pub struct FilePrefix {
     pub directory_path: std::path::PathBuf,
     pub file_base: String,
 }
 
 impl FilePrefix {
-    pub fn with_suffix(&self, suffix: &str) -> std::path::PathBuf {
+    pub fn full_path_with_suffix(&self, suffix: &str) -> std::path::PathBuf {
         self.directory_path.join(self.file_base.clone() + suffix)
     }
 
     pub fn create_file_with_suffix(&self, suffix: &str) -> std::io::BufWriter<std::fs::File> {
-        let path = self.with_suffix(suffix);
-        let file = std::fs::File::create(&path)
-            .unwrap_or_else(|_| panic!("failed to create file: {:?}", path));
+        let filename = self.full_path_with_suffix(suffix);
+        let file = std::fs::File::create(&filename)
+            .unwrap_or_else(|_| panic!("ERROR:  Unable to write file: {:?}", filename));
         std::io::BufWriter::new(file)
+    }
+
+    /**
+     * Edits the `directory_path` in place by joining a sub-directory, and then ensures that
+     * the newly created directory exists.
+     */
+    pub fn create_and_step_into_sub_directory(&mut self, sub_directory: &str) {
+        self.directory_path = self.directory_path.join(sub_directory);
+        std::fs::create_dir_all(&self.directory_path).unwrap();
     }
 }

--- a/src/core/image_utils.rs
+++ b/src/core/image_utils.rs
@@ -1,3 +1,4 @@
+use image::{ImageBuffer, Rgb, Rgba};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
@@ -345,6 +346,27 @@ pub fn generate_scalar_image_in_place<F>(
             *elem = pixel_renderer(&nalgebra::Vector2::<f64>::new(re, im));
         });
     });
+}
+
+pub fn write_rgb_image_to_file_or_panic(
+    filename: std::path::PathBuf,
+    imgbuf: &ImageBuffer<Rgb<u8>, Vec<u8>>,
+) {
+    imgbuf
+        .save(&filename)
+        .unwrap_or_else(|_| panic!("ERROR:  Unable to write image file: {}", filename.display()));
+    println!("INFO:  Wrote image file to: {}", filename.display());
+}
+
+// TODO:  figure out how to use a common implementation with `write_rgb_image_to_file_or_panic`.
+pub fn write_rgba_image_to_file_or_panic(
+    filename: std::path::PathBuf,
+    imgbuf: &ImageBuffer<Rgba<u8>, Vec<u8>>,
+) {
+    imgbuf
+        .save(&filename)
+        .unwrap_or_else(|_| panic!("ERROR:  Unable to write image file: {}", filename.display()));
+    println!("INFO:  Wrote image file to: {}", filename.display());
 }
 
 #[cfg(test)]

--- a/src/fractals/barnsley_fern.rs
+++ b/src/fractals/barnsley_fern.rs
@@ -1,5 +1,5 @@
 use crate::core::chaos_game::{chaos_game_render, ColoredPoint};
-use crate::core::file_io::FilePrefix;
+use crate::core::file_io::{serialize_to_json_or_panic, FilePrefix};
 use crate::core::image_utils::{FitImage, ViewRectangle};
 use rand::distributions::{Distribution, Uniform};
 use rand::Rng;
@@ -118,7 +118,7 @@ impl SampleGenerator {
  */
 pub fn render_barnsley_fern(
     params: &BarnsleyFernParams,
-    file_prefix: &FilePrefix,
+    file_prefix: FilePrefix,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Set up the "fern sample distribution":
     let mut sample_point = nalgebra::Vector2::<f64>::new(0.0, 0.0);
@@ -134,6 +134,8 @@ pub fn render_barnsley_fern(
         }
     };
 
+    serialize_to_json_or_panic(file_prefix.full_path_with_suffix(".json"), &params);
+
     chaos_game_render(
         image::Rgba(params.background_color_rgba),
         &mut distribution,
@@ -143,6 +145,5 @@ pub fn render_barnsley_fern(
             .fit_image
             .image_specification(&params.coeffs.view_rectangle),
         file_prefix,
-        &serde_json::to_string(params)?,
     )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use core::file_io::{
 };
 
 use clap::Parser;
-use cli::args::{CommandsEnum, FractalRendererArgs};
+use cli::args::{CommandsEnum, FractalRendererArgs, ParameterFilePath};
 use cli::explore::explore_fractal;
 use cli::render::render_fractal;
 use fractals::common::FractalParams;
@@ -11,6 +11,16 @@ use fractals::common::FractalParams;
 mod cli;
 mod core;
 mod fractals;
+
+fn build_file_prefix(params: &ParameterFilePath, command_name: &str) -> FilePrefix {
+    FilePrefix {
+        directory_path: build_output_path_with_date_time(
+            command_name,
+            &maybe_date_time_string(params.date_time_out),
+        ),
+        file_base: extract_base_name(&params.params_path).to_owned(),
+    }
+}
 
 fn main() {
     let args: FractalRendererArgs = FractalRendererArgs::parse();
@@ -22,22 +32,19 @@ fn main() {
 
     match &args.command {
         Some(CommandsEnum::Render(params)) => {
-            let build_file_prefix = |base_name: &str| -> FilePrefix {
-                FilePrefix {
-                    directory_path: build_output_path_with_date_time(
-                        &params.params_path,
-                        base_name,
-                        &maybe_date_time_string(params.date_time_out),
-                    ),
-                    file_base: extract_base_name(&params.params_path).to_owned(),
-                }
-            };
-
-            render_fractal(&fractal_params(&params.params_path), build_file_prefix).unwrap();
+            render_fractal(
+                &fractal_params(&params.params_path),
+                build_file_prefix(params, "render"),
+            )
+            .unwrap();
         }
 
         Some(CommandsEnum::Explore(params)) => {
-            explore_fractal(&fractal_params(&params.params_path)).unwrap();
+            explore_fractal(
+                &fractal_params(&params.params_path),
+                build_file_prefix(params, "explore"),
+            )
+            .unwrap();
         }
 
         None => {


### PR DESCRIPTION
-- reorganize and simplify the structure and
utilities around the `out` directory where the
images and diagnostic files are saved.

-- use standardize function calls for writing
files to disk and reporting errors to the user
on failure  (panic with clear message).

-- more file paths into functions, rather than
passing by reference, when they are not needed
in the parent scope.

-- standardize naming for json specification of
pixel colors.

(Pulled out of https://github.com/MatthewPeterKelly/fractal-renderer/pull/72, which was growing too large in scope.)