### PR TITLE
Add shadow fern QHD example

### DIFF
--- a/examples/barnsley_fern/shadow_fern_QHD.json
+++ b/examples/barnsley_fern/shadow_fern_QHD.json
@@ -1,0 +1,38 @@
+{
+  "BarnsleyFern": {
+    "fit_image": {
+      "resolution": [2560, 1600],
+      "padding_scale": 1.01
+    },
+    "sample_count": 100000000,
+    "subpixel_antialiasing": 8,
+    "background_color_rgba": [0, 0, 0, 255],
+    "fern_color_rgba": [79, 121, 66, 255],
+    "coeffs": {
+      "view_rectangle": {
+        "center": [0, 5],
+        "dimensions": [6, 10]
+      },
+      "f1_map": {
+        "linear": [0, 0, 0, 0.16],
+        "offset": [0, 0],
+        "weight": 0.01
+      },
+      "f2_map": {
+        "linear": [0.85, -0.04, 0.04, 0.85],
+        "offset": [0, 1.6],
+        "weight": 0.85
+      },
+      "f3_map": {
+        "linear": [0.2, 0.23, -0.26, 0.22],
+        "offset": [0, 1.6],
+        "weight": 0.07
+      },
+      "f4_map": {
+        "linear": [-0.15, 0.26, 0.28, 0.24],
+        "offset": [0, 0.44],
+        "weight": 0.07
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is one of my favorite fractals that I've generated so far. It is the barnsley fern with anti-aliasing turned all of the way up, but then not run fully to convergence. The result is that some of the less-commonly sampled regions show up as "in shadow", which looks neat:
![shadow_fern_QHD](https://github.com/user-attachments/assets/6df42bbb-75e1-4214-9adc-efd49ffe3dec)

