### PR TITLE
Clean-up image save utility functions

### DIFF
--- a/src/cli/color_swatch.rs
+++ b/src/cli/color_swatch.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::{
     color_map::{ColorMapKeyFrame, PiecewiseLinearColorMap},
     file_io::{serialize_to_json_or_panic, FilePrefix},
-    image_utils::write_rgb_image_to_file_or_panic,
+    image_utils::write_image_to_file_or_panic,
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -59,5 +59,7 @@ pub fn generate_color_swatch(params_path: &str, file_prefix: FilePrefix) {
         }
     }
 
-    write_rgb_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), &imgbuf);
+    write_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), |f| {
+        imgbuf.save(f)
+    });
 }

--- a/src/cli/explore.rs
+++ b/src/cli/explore.rs
@@ -12,7 +12,7 @@ use crate::{
         file_io::{date_time_string, serialize_to_json_or_panic, FilePrefix},
         histogram::{insert_buffer_into_histogram, CumulativeDistributionFunction, Histogram},
         image_utils::{
-            create_buffer, generate_scalar_image_in_place, write_rgb_image_to_file_or_panic,
+            create_buffer, generate_scalar_image_in_place, write_image_to_file_or_panic,
             ImageSpecification, PixelMapper,
         },
     },
@@ -323,10 +323,10 @@ impl PixelGrid {
             *pixel = color_map(cdf.percentile(self.display_buffer[x as usize][y as usize]));
         }
 
-        write_rgb_image_to_file_or_panic(
+        write_image_to_file_or_panic(
             self.file_prefix
                 .full_path_with_suffix(&format!("_{}.png", datetime)),
-            &imgbuf,
+            |f| imgbuf.save(f),
         );
     }
 }

--- a/src/core/chaos_game.rs
+++ b/src/core/chaos_game.rs
@@ -16,7 +16,7 @@ use crate::core::{
     image_utils::{elapsed_and_reset, ImageSpecification, SubpixelGridMask, UpsampledPixelMapper},
 };
 
-use super::image_utils::write_rgba_image_to_file_or_panic;
+use super::image_utils::write_image_to_file_or_panic;
 
 /**
  * Timing data, used for simple analysis logging.
@@ -103,7 +103,9 @@ where
 
     timer.sampling = elapsed_and_reset(&mut stopwatch);
 
-    write_rgba_image_to_file_or_panic(file_prefix.full_path_with_suffix("_raw.png"), &imgbuf);
+    write_image_to_file_or_panic(file_prefix.full_path_with_suffix("_raw.png"), |f| {
+        imgbuf.save(f)
+    });
     timer.write_raw_png = elapsed_and_reset(&mut stopwatch);
 
     // Scale back the colors toward the background, based on the subpixel sample data:
@@ -125,7 +127,9 @@ where
     }
     timer.antialiasing_post_process = elapsed_and_reset(&mut stopwatch);
 
-    write_rgba_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), &imgbuf);
+    write_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), |f| {
+        imgbuf.save(f)
+    });
     timer.write_raw_png = elapsed_and_reset(&mut stopwatch);
 
     let mut diagnostics_file = file_prefix.create_file_with_suffix("_diagnostics.txt");

--- a/src/core/image_utils.rs
+++ b/src/core/image_utils.rs
@@ -1,7 +1,9 @@
-use image::{ImageBuffer, Rgb, Rgba};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ImageSpecification {
@@ -348,23 +350,11 @@ pub fn generate_scalar_image_in_place<F>(
     });
 }
 
-pub fn write_rgb_image_to_file_or_panic(
-    filename: std::path::PathBuf,
-    imgbuf: &ImageBuffer<Rgb<u8>, Vec<u8>>,
-) {
-    imgbuf
-        .save(&filename)
-        .unwrap_or_else(|_| panic!("ERROR:  Unable to write image file: {}", filename.display()));
-    println!("INFO:  Wrote image file to: {}", filename.display());
-}
-
-// TODO:  figure out how to use a common implementation with `write_rgb_image_to_file_or_panic`.
-pub fn write_rgba_image_to_file_or_panic(
-    filename: std::path::PathBuf,
-    imgbuf: &ImageBuffer<Rgba<u8>, Vec<u8>>,
-) {
-    imgbuf
-        .save(&filename)
+pub fn write_image_to_file_or_panic<F, T, E>(filename: std::path::PathBuf, save_lambda: F)
+where
+    F: FnOnce(&PathBuf) -> Result<T, E>,
+{
+    save_lambda(&filename)
         .unwrap_or_else(|_| panic!("ERROR:  Unable to write image file: {}", filename.display()));
     println!("INFO:  Wrote image file to: {}", filename.display());
 }

--- a/src/fractals/driven_damped_pendulum.rs
+++ b/src/fractals/driven_damped_pendulum.rs
@@ -1,8 +1,7 @@
 use crate::core::{
     file_io::{serialize_to_json_or_panic, FilePrefix},
     image_utils::{
-        elapsed_and_reset, generate_scalar_image, write_rgb_image_to_file_or_panic,
-        ImageSpecification,
+        elapsed_and_reset, generate_scalar_image, write_image_to_file_or_panic, ImageSpecification,
     },
     ode_solvers::rk4_simulate,
 };
@@ -203,7 +202,9 @@ pub fn render_driven_damped_pendulum_attractor(
         *pixel = color_map(raw_data[x as usize][y as usize]);
     }
 
-    write_rgb_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), &imgbuf);
+    write_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), |f| {
+        imgbuf.save(f)
+    });
     timer.write_png = elapsed_and_reset(&mut stopwatch);
 
     timer.display(&mut file_prefix.create_file_with_suffix("_diagnostics.txt"))?;

--- a/src/fractals/mandelbrot.rs
+++ b/src/fractals/mandelbrot.rs
@@ -7,8 +7,7 @@ use crate::core::{
     file_io::{serialize_to_json_or_panic, FilePrefix},
     histogram::{insert_buffer_into_histogram, CumulativeDistributionFunction, Histogram},
     image_utils::{
-        elapsed_and_reset, generate_scalar_image, write_rgb_image_to_file_or_panic,
-        ImageSpecification,
+        elapsed_and_reset, generate_scalar_image, write_image_to_file_or_panic, ImageSpecification,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -218,7 +217,9 @@ pub fn render_mandelbrot_set(
     }
 
     timer.color_map = elapsed_and_reset(&mut stopwatch);
-    write_rgb_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), &imgbuf);
+    write_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), |f| {
+        imgbuf.save(f)
+    });
     timer.write_png = elapsed_and_reset(&mut stopwatch);
 
     let mut diagnostics_file = file_prefix.create_file_with_suffix("_diagnostics.txt");


### PR DESCRIPTION
Replace two near-identical utility functions with
a single function that uses a lambda to abstract
away the differences between the different image
buffers used in different parts of the project.