### PR TITLE
Rewrite color map and fix bug

### DIFF
--- a/src/cli/color_swatch.rs
+++ b/src/cli/color_swatch.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::{
     color_map::{
         with_uniform_spacing, ColorMap, ColorMapKeyFrame, ColorMapper, LinearInterpolator,
-        NearestInterpolator,
+        StepInterpolator,
     },
     file_io::{serialize_to_json_or_panic, FilePrefix},
     image_utils::write_image_to_file_or_panic,
@@ -35,9 +35,15 @@ pub fn generate_color_swatch(params_path: &str, file_prefix: FilePrefix) {
     let uniform_keyframes = with_uniform_spacing(&params.keyframes);
     let color_maps: Vec<Box<dyn ColorMapper>> = vec![
         Box::new(ColorMap::new(&params.keyframes, LinearInterpolator {})),
-        Box::new(ColorMap::new(&params.keyframes, NearestInterpolator {})),
+        Box::new(ColorMap::new(
+            &params.keyframes,
+            StepInterpolator { threshold: 0.5 },
+        )),
         Box::new(ColorMap::new(&uniform_keyframes, LinearInterpolator {})),
-        Box::new(ColorMap::new(&uniform_keyframes, NearestInterpolator {})),
+        Box::new(ColorMap::new(
+            &uniform_keyframes,
+            StepInterpolator { threshold: 0.5 },
+        )),
     ];
 
     // Save the image to a file, deducing the type from the file name


### PR DESCRIPTION
Rewrites the color map utility to properly support different interpolation types. The interpolation type is handled using generics, so that we can avoid a run-time check on every call to evaluate the color map. This should make it much faster, eg, for using in the GUI, allowing the color map to be recomputed on the fly in response to user input.

Along the way, I found and fixed a bug in the `color_swatch` utility --> now the color swatch is drawn correctly.