### PR TITLE
Switch README to use unix delimeters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,34 @@ Initial goal: write a simple CLI for generating high-quality images of the mande
 
 Long-term goal: add support for zoom sequences and other fractals, along with (maybe?) a browser interface.
 
-## Usage (Windows; flip path delimerer to `/` for unix-based)
+## Usage Examples:
 
 ```
-cargo run --release -- render .\examples\mandelbrot\default.json
-```
-
-```
-cargo run --release -- render .\examples\driven_damped_pendulum\default.json
+cargo run --release -- render ./examples/mandelbrot/default.json
 ```
 
 ```
-cargo run --release -- render .\examples\driven_damped_pendulum\default_series.json
+cargo run --release -- render ./examples/driven_damped_pendulum/default.json
 ```
 
 ```
-cargo run --release -- render .\examples\barnsley_fern\default.json
+cargo run --release -- render ./examples/driven_damped_pendulum/default_series.json
 ```
 
 ```
-cargo run --release -- render .\examples\serpinsky\triangle.json
+cargo run --release -- render ./examples/barnsley_fern/default.json
 ```
 
 ```
-cargo run --release -- explore .\examples\mandelbrot\default.json
+cargo run --release -- render ./examples/serpinsky/triangle.json
 ```
 
 ```
-cargo run color-swatch -- examples\color_swatch\rainbow.json
+cargo run --release -- explore ./examples/mandelbrot/default.json
+```
+
+```
+cargo run color-swatch -- examples/color_swatch/rainbow.json
 ```
 
 ## Autoformatting:
@@ -90,6 +90,5 @@ ffmpeg -i out/default_series.mp4 out/default_series.gif
 
 ## Acknowledgements
 
-Thanks to the excellent example from the [pixel.rs](https://docs.rs/pixels), which was really helpful in getting the GUI working.
-
+Thanks to the excellent example from the [pixel.rs](https://docs.rs/pixels), which was really helpful in getting the GUI working:
 https://github.com/parasyte/pixels/tree/39e84aacbe117347e7b8e7201c48184344aed9cc/examples/conway


### PR DESCRIPTION
Turns out these work fine on Windows too.