### PR TITLE
Add SimpleLinearControl; ODE Test

### DIFF
--- a/src/core/dynamical_systems.rs
+++ b/src/core/dynamical_systems.rs
@@ -1,0 +1,124 @@
+//! Collection of simple dynamical systems
+
+#[cfg(test)]
+use nalgebra::Vector2;
+#[cfg(test)]
+pub struct SimpleLinearControl {
+    pub xi: f64,    // damping ratio
+    pub omega: f64, // natural frequency
+}
+#[cfg(test)]
+impl SimpleLinearControl {
+    /// Constant that is used to map between the rise time and omega (natural frequency)
+    /// for a critically damped (xi == 1.0) system:
+    ///
+    /// CRITICALLY_DAMPED_RISE_TIME_SCALE_FACTOR = rise_time * omega;
+    #[cfg(test)]
+    pub const CRITICALLY_DAMPED_RISE_TIME_SCALE_FACTOR: f64 = 3.357908561477796;
+
+    /// Computes x(t) for critically damped, overdamped, and underdamped cases
+    #[cfg(test)]
+    pub fn evaluate_solution(&self, t: f64) -> f64 {
+        if self.xi == 1.0 {
+            self.critically_damped(t)
+        } else if self.xi > 1.0 {
+            self.overdamped(t)
+        } else {
+            self.underdamped(t)
+        }
+    }
+
+    /// xi == 1.0
+    ///
+    /// Special case:  what is the rise time of a critically damped system?
+    ///
+    ///  Define "rise time" as the time to go from 0.1 to 0.9, for a step change
+    ///  from an initial condition of zero, to a reference of  1.0.
+    ///
+    ///  Let omega == 1.0, then we find...
+    ///  f(0.5318116083896343) = 0.1
+    ///  f(3.88972016986743) = 0.9
+    ///  Rise Time: 3.357908561477796
+    ///
+    #[cfg(test)]
+    fn critically_damped(&self, t: f64) -> f64 {
+        let w = self.omega;
+        (-1.0 - w * t) * (-w * t).exp() + 1.0
+    }
+
+    /// xi > 1.0
+    #[cfg(test)]
+    fn overdamped(&self, t: f64) -> f64 {
+        let xi = self.xi;
+        let w = self.omega;
+        let alpha1 = -xi + (xi * xi - 1.0).sqrt();
+        let alpha2 = -xi - (xi * xi - 1.0).sqrt();
+        let a = -alpha2 / (alpha2 - alpha1);
+        let b = alpha1 / (alpha2 - alpha1);
+        a * (alpha1 * w * t).exp() + b * (alpha2 * w * t).exp() + 1.0
+    }
+
+    /// xi < 1.0
+    #[cfg(test)]
+    fn underdamped(&self, t: f64) -> f64 {
+        let xi = self.xi;
+        let w = self.omega;
+        let omega_d = w * (1.0 - xi * xi).sqrt();
+        let damping_factor = (-xi * w * t).exp();
+        let cosine = (omega_d * t).cos();
+        let sine = (omega_d * t).sin();
+        damping_factor * (-cosine - (xi / (1.0 - xi * xi).sqrt()) * sine) + 1.0
+    }
+
+    /// Implements the model as a discrete linear controller:
+    ///
+    /// acc = Kp * (x_ref - x) + Kd * (v_ref - v)
+    #[cfg(test)]
+    pub fn system_dynamics(
+        &self,
+        reference: &Vector2<f64>,
+    ) -> impl Fn(f64, Vector2<f64>) -> Vector2<f64> {
+        let k_p = self.omega * self.omega;
+        let k_d = 2.0 * self.xi * self.omega;
+        let x_ref = reference[0];
+        let v_ref = reference[1];
+
+        move |_, state: Vector2<f64>| {
+            let x = state[0];
+            let v = state[1];
+
+            let v_dot = k_p * (x_ref - x) + k_d * (v_ref - v);
+            let x_dot = v;
+            Vector2::new(x_dot, v_dot)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_closed_loop_controller_critically_damped_rise_time() {
+        let dyn_sys = SimpleLinearControl {
+            omega: 1.0,
+            xi: 1.0,
+        };
+
+        // Regression test on the known rise time properties.
+        // Computed offline by a nonlinear root solve.
+        let t0 = 0.5318116083896343;
+        let t1 = 3.88972016986743;
+        let x0 = dyn_sys.evaluate_solution(t0);
+        let x1 = dyn_sys.evaluate_solution(t1);
+
+        assert_relative_eq!(x0, 0.1, epsilon = 1e-6);
+        assert_relative_eq!(x1, 0.9, epsilon = 1e-6);
+        assert_relative_eq!(
+            t1 - t0,
+            SimpleLinearControl::CRITICALLY_DAMPED_RISE_TIME_SCALE_FACTOR / dyn_sys.omega,
+            epsilon = 1e-6
+        )
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod chaos_game;
 pub mod color_map;
+pub mod dynamical_systems;
 pub mod file_io;
 pub mod histogram;
 pub mod image_utils;

--- a/src/core/ode_solvers.rs
+++ b/src/core/ode_solvers.rs
@@ -1,10 +1,10 @@
 //! Explicit ODE solvers
 
-extern crate nalgebra as na;
+use nalgebra::Vector2;
 
-pub fn rk4_method_step<F>(dt: f64, t: f64, x: na::Vector2<f64>, dynamics: &F) -> na::Vector2<f64>
+pub fn rk4_method_step<F>(dt: f64, t: f64, x: Vector2<f64>, dynamics: &F) -> Vector2<f64>
 where
-    F: Fn(f64, na::Vector2<f64>) -> na::Vector2<f64>,
+    F: Fn(f64, Vector2<f64>) -> Vector2<f64>,
 {
     let t_mid = t + 0.5 * dt;
     let t_next = t + dt;
@@ -21,11 +21,11 @@ pub fn rk4_simulate<F>(
     t_begin: f64,
     t_final: f64,
     n_steps: u32,
-    x0: na::Vector2<f64>,
+    x0: Vector2<f64>,
     dynamics: &F,
-) -> na::Vector2<f64>
+) -> Vector2<f64>
 where
-    F: Fn(f64, na::Vector2<f64>) -> na::Vector2<f64>,
+    F: Fn(f64, Vector2<f64>) -> Vector2<f64>,
 {
     let dt = (t_final - t_begin) / (n_steps as f64);
     let mut x = x0;
@@ -35,4 +35,48 @@ where
         x = rk4_method_step(dt, t, x, dynamics);
     }
     x
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::dynamical_systems::SimpleLinearControl;
+
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_closed_loop_controller_analytic_soln() {
+        let natural_frequency = 2.0;
+        let damping_ratio_test_values = [1.0, 1.2, 0.8]; // Critically damped, overdamped, underdamped
+        let t_begin = 0.0;
+        let t_final = 3.0;
+        let n_steps = 500;
+        let dt = (t_final - t_begin) / (n_steps as f64);
+
+        let target_state = Vector2::new(1.0, 0.0);
+
+        for &damping_ratio in &damping_ratio_test_values {
+            let control_model = SimpleLinearControl {
+                omega: natural_frequency,
+                xi: damping_ratio,
+            };
+
+            // Define system dynamics and analytical solution
+            let dynamics = control_model.system_dynamics(&target_state);
+            let analytical_solution = |t: f64| control_model.evaluate_solution(t);
+
+            // Run RK4 simulation
+            let mut state = Vector2::new(0.0, 0.0);
+            let pos_err_tol = 1e-3;
+            for i in 0..=n_steps {
+                let t = t_begin + (i as f64) * dt;
+
+                // Compare numerical solution (state[0]) with analytical solution
+                assert_relative_eq!(state[0], analytical_solution(t), epsilon = pos_err_tol);
+
+                // Step forward using RK4
+                state = rk4_method_step(dt, t, state, &dynamics);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds the `SimpleLinearControl` test system to the new `dynamical_systems` module, along with a basic self test.

Use the `SimpleLinearControl` model system to create a nice test for the ODE solver suite, showing that we can exactly (within numerical tolerance) match the analytic solution for various controller gains.

Implemented as part of https://github.com/MatthewPeterKelly/fractal-renderer/pull/97, pulling it out here into its own PR for clarity.