### PR TITLE
Use constant speed controller

### DIFF
--- a/src/cli/explore.rs
+++ b/src/cli/explore.rs
@@ -23,7 +23,6 @@ use crate::{
     fractals::{common::FractalParams, quadratic_map::QuadraticMap},
 };
 
-const RISE_TIME: f64 = 0.1; // seconds
 const ZOOM_RATE: f64 = 0.4; // dimensionless. See `ViewControl` docs.
 const PAN_RATE: f64 = 0.2; // window width per second
 
@@ -120,13 +119,7 @@ pub fn explore_fractal(params: &FractalParams, mut file_prefix: FilePrefix) -> R
             Box::new(PixelGrid::new(
                 stopwatch.total_elapsed_seconds(),
                 file_prefix,
-                ViewControl::new(
-                    time,
-                    PAN_RATE,
-                    ZOOM_RATE,
-                    RISE_TIME,
-                    &inner_params.image_specification,
-                ),
+                ViewControl::new(time, PAN_RATE, ZOOM_RATE, &inner_params.image_specification),
                 QuadraticMap::new((**inner_params).clone()),
             ))
         }
@@ -135,13 +128,7 @@ pub fn explore_fractal(params: &FractalParams, mut file_prefix: FilePrefix) -> R
             Box::new(PixelGrid::new(
                 stopwatch.total_elapsed_seconds(),
                 file_prefix,
-                ViewControl::new(
-                    time,
-                    PAN_RATE,
-                    ZOOM_RATE,
-                    RISE_TIME,
-                    &inner_params.image_specification,
-                ),
+                ViewControl::new(time, PAN_RATE, ZOOM_RATE, &inner_params.image_specification),
                 QuadraticMap::new((**inner_params).clone()),
             ))
         }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -1,118 +1,40 @@
-use serde::{Deserialize, Serialize};
-
-use crate::core::dynamical_systems::SimpleLinearControl;
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct PointState {
-    pub pos: f64,
-    pub vel: f64,
-}
-
-impl PointState {
-    pub fn time_step_physics(&mut self, delta_time: f64, acc: f64) {
-        // Symplectic Euler's method... stable first order ODE step.
-        self.vel += acc * delta_time;
-        self.pos += self.vel * delta_time;
-    }
-}
-
 #[derive(Clone, Debug)]
 pub enum Target {
     Position { pos_ref: f64, max_vel: f64 },
     Velocity { vel_ref: f64 },
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+/// TODO
+/// @return: next position
+pub fn update_position(position: f64, delta_time: f64, target: &Target) -> f64 {
+    match *target {
+        Target::Position { pos_ref, max_vel } => {
+            let pos_err = pos_ref - position;
+            let max_pos_delta = (max_vel * delta_time).abs();
 
-pub struct Controller {
-    pub gains: PointState,
-    pub vel_err_int: f64, // velocity error integrator state
-}
-
-impl Controller {
-    pub fn gains_from_damping_and_natural_frequency(
-        damping_ratio: f64,
-        natural_frequency: f64,
-    ) -> PointState {
-        let kd = 2.0 * damping_ratio * natural_frequency;
-        let kp = natural_frequency * natural_frequency;
-        PointState { pos: kp, vel: kd }
-    }
-
-    pub fn from_rise_time(rise_time: f64) -> Controller {
-        // See the `test_closed_loop_controller_critically_damped_rise_time()`
-        // test in `ode_solvers` for an idea of how the 3.357... value is found.
-        Controller::new(Self::gains_from_damping_and_natural_frequency(
-            1.0,
-            SimpleLinearControl::CRITICALLY_DAMPED_RISE_TIME_SCALE_FACTOR / rise_time,
-        ))
-    }
-
-    pub fn new(gains: PointState) -> Controller {
-        Controller {
-            gains,
-            vel_err_int: 0.0,
+            if max_pos_delta > pos_err.abs() {
+                return pos_ref;
+            }
+            let pos_err_clamped = pos_err.clamp(-max_pos_delta, max_pos_delta);
+            position + pos_err_clamped
         }
-    }
-
-    /// Fancy PD controller that works for both "position" and "velocity"
-    /// control modes. The key feature here is that we can smoothly switch
-    /// between the two modes while supporting velocity limits in position
-    /// control. This allows the controller to accept position references
-    /// that are arbitrarily far away, by smoothly ramping up to the max
-    /// speed and then ramping back down to zero as it reaches the target.
-    /// Note: the "integral" gain on the velocity controller does not have
-    /// a proper "anti-wind-up" feature, because we assume that the command
-    /// acceleration will be applied perfectly to the state by PointTracker.
-    pub fn update_and_compute_acceleration(
-        &mut self,
-        state: &PointState,
-        delta_time: f64,
-        target: &Target,
-    ) -> f64 {
-        let (pos_err, vel_err) = match *target {
-            Target::Position { pos_ref, max_vel } => {
-                // Fancy math: compute the max pos err S.T. velocity saturates at max_vel
-                // Note:  should be positive; all three terms on the RHS are positive...
-                // but if the user does something silly, then the `abs()` prevents a crash.
-                let max_pos_err = (self.gains.vel * max_vel / self.gains.pos).abs();
-
-                let pos_err = pos_ref - state.pos;
-                let pos_err = pos_err.clamp(-max_pos_err, max_pos_err);
-                self.vel_err_int = 0.0;
-                (pos_err, -state.vel)
-            }
-            Target::Velocity { vel_ref } => {
-                let vel_err = vel_ref - state.vel;
-                self.vel_err_int += delta_time * vel_err;
-                (self.vel_err_int, vel_err)
-            }
-        };
-
-        // Simple PD controller to compute the acceleration
-        pos_err * self.gains.pos + vel_err * self.gains.vel
+        Target::Velocity { vel_ref } => position + vel_ref * delta_time,
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct PointTracker {
-    controller: Controller,
-    state: PointState,
+    position: f64,
     target: Target,
     time: f64,
-    max_time_step: f64,
 }
 
 impl PointTracker {
-    pub const MINIMUM_INTEGRATION_STEP_COUNT_PER_RISE_TIME: f64 = 5.0;
-
-    pub fn new(time: f64, pos: f64, rise_time: f64) -> PointTracker {
+    pub fn new(time: f64, pos: f64) -> PointTracker {
         PointTracker {
-            controller: Controller::from_rise_time(rise_time),
-            state: PointState { pos, vel: 0.0 },
+            position: pos,
             target: Target::Velocity { vel_ref: 0.0 },
             time,
-            max_time_step: rise_time / Self::MINIMUM_INTEGRATION_STEP_COUNT_PER_RISE_TIME,
         }
     }
 
@@ -120,139 +42,14 @@ impl PointTracker {
         self.target = target;
     }
 
-    pub fn state(&self) -> &PointState {
-        &self.state
+    pub fn position(&self) -> f64 {
+        self.position
     }
 
     pub fn update_and_return_pos(&mut self, time: f64) -> f64 {
         let delta_time = time - self.time;
-        let num_steps = (delta_time / self.max_time_step).ceil();
-        let dt = delta_time / num_steps;
-
-        for _ in 0..(num_steps as u32) {
-            self.physics_step(dt);
-        }
-        self.state.pos
-    }
-
-    fn physics_step(&mut self, delta_time: f64) {
-        let acc =
-            self.controller
-                .update_and_compute_acceleration(&self.state, delta_time, &self.target);
-        self.state.time_step_physics(delta_time, acc);
         self.time += delta_time;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use approx::assert_relative_eq;
-    use more_asserts::assert_le;
-
-    use super::*;
-
-    #[test]
-    fn test_steady_state_at_position_target() {
-        let rise_time = 0.2;
-        let pos_init = 0.5;
-        let time_init = 1.1;
-        let mut tracker = PointTracker::new(time_init, pos_init, rise_time);
-
-        // Select a velocity limit that we will actually hit...
-        // ... but then run long enough to actually hit the target position.
-
-        let pos_ref = -0.4;
-        let max_vel = 8.0;
-        tracker.set_target(Target::Position { pos_ref, max_vel });
-
-        // Check the the "internal physics sub-step" works properly:
-        let time_final = time_init + 20.0 * rise_time;
-        let pos_final = tracker.update_and_return_pos(time_final);
-
-        let tol = 1e-3;
-        assert_relative_eq!(tracker.time, time_final, epsilon = tol);
-        assert_eq!(tracker.state.pos, pos_final);
-        assert_relative_eq!(pos_final, pos_ref, epsilon = tol);
-        assert_relative_eq!(tracker.state.vel, 0.0, epsilon = tol);
-    }
-
-    #[test]
-    fn test_position_mode_velocity_limit() {
-        let rise_time = 0.2;
-        let pos_init = 0.5;
-        let time_init = 1.1;
-        let mut tracker = PointTracker::new(time_init, pos_init, rise_time);
-
-        // Small velocity limit, far away position --> ensure we don't violate the limits
-        let max_vel = 0.2;
-        let pos_ref = -25.0; // Don't actually expect to reach this
-        tracker.set_target(Target::Position { pos_ref, max_vel });
-        let dt = 0.3 * rise_time;
-        let time_final = tracker.time + 3.0 * rise_time;
-        while tracker.time < time_final {
-            tracker.update_and_return_pos(tracker.time + dt);
-            assert_le!(tracker.state.vel.abs(), max_vel);
-        }
-        // Verify that we actually hit steady-state at the max velocity
-        assert_relative_eq!(tracker.state.vel, -max_vel, epsilon = 1e-5);
-
-        // Switch directions, and check velocity limits again.
-        let pos_ref = 51.0;
-        tracker.set_target(Target::Position { pos_ref, max_vel });
-        let time_final = tracker.time + 3.0 * rise_time;
-        while tracker.time < time_final {
-            tracker.update_and_return_pos(tracker.time + dt);
-            assert_le!(tracker.state.vel.abs(), max_vel);
-        }
-        // Verify that we actually hit steady-state at the max velocity
-        assert_relative_eq!(tracker.state.vel, max_vel, epsilon = 1e-5);
-    }
-
-    #[test]
-    fn test_position_mode_convergence() {
-        let rise_time = 0.2;
-        let pos_init = 1.0;
-        let time_init = 1.1;
-        let mut tracker = PointTracker::new(time_init, pos_init, rise_time);
-
-        // Large velocity limit, close position --> verify critically damped convergence
-        let max_vel = 1000.0;
-        let pos_ref = 2.0;
-        tracker.set_target(Target::Position { pos_ref, max_vel });
-        let dt = 0.1 * rise_time;
-        let time_final = time_init + 8.0 * rise_time;
-        while tracker.time < time_final {
-            let time = tracker.time + dt;
-            let cached_state = tracker.state;
-            tracker.update_and_return_pos(time);
-            let old_pos_err = (cached_state.pos - pos_ref).abs();
-            let new_pos_err = (tracker.state.pos - pos_ref).abs();
-            assert_le!(new_pos_err, old_pos_err);
-            assert_le!(tracker.state.vel, max_vel);
-        }
-    }
-
-    #[test]
-    fn test_velocity_mode_convergence() {
-        let rise_time = 0.4;
-        let pos_init = -0.3;
-        let time_init = 1.1;
-        let mut tracker = PointTracker::new(time_init, pos_init, rise_time);
-
-        let vel_ref = 0.9;
-        let time_final = time_init + 3.0 * rise_time;
-
-        tracker.set_target(Target::Velocity { vel_ref });
-
-        let dt = 0.3 * rise_time;
-        let overshoot_tol = 0.1;
-        while tracker.time < time_final {
-            let time = tracker.time + dt;
-            let cached_state = tracker.state;
-            tracker.update_and_return_pos(time);
-            let old_vel_err = (cached_state.vel - vel_ref).abs();
-            let new_vel_err = (tracker.state.vel - vel_ref).abs();
-            assert_le!(new_vel_err, old_vel_err + overshoot_tol);
-        }
+        self.position = update_position(self.position, delta_time, &self.target);
+        self.position
     }
 }

--- a/src/core/dynamical_systems.rs
+++ b/src/core/dynamical_systems.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 use nalgebra::Vector2;
-
+#[cfg(test)]
 pub struct SimpleLinearControl {
     #[cfg(test)]
     pub xi: f64, // damping ratio
@@ -10,6 +10,7 @@ pub struct SimpleLinearControl {
     pub omega: f64, // natural frequency
 }
 
+#[cfg(test)]
 impl SimpleLinearControl {
     /// Constant that is used to map between the rise time and omega (natural frequency)
     /// for a critically damped (xi == 1.0) system:

--- a/src/core/view_control.rs
+++ b/src/core/view_control.rs
@@ -142,7 +142,6 @@ impl ViewControl {
         time: f64,
         pan_rate: f64,
         zoom_rate: f64,
-        rise_time: f64,
         image_specification: &ImageSpecification,
     ) -> Self {
         Self {
@@ -151,17 +150,17 @@ impl ViewControl {
             image_specification: image_specification.clone(),
             maybe_target_command: None,
             pan_control: [
-                PointTracker::new(time, image_specification.center[0], rise_time),
-                PointTracker::new(time, image_specification.center[1], rise_time),
+                PointTracker::new(time, image_specification.center[0]),
+                PointTracker::new(time, image_specification.center[1]),
             ],
-            zoom_control: PointTracker::new(time, image_specification.width.ln(), rise_time),
+            zoom_control: PointTracker::new(time, image_specification.width.ln()),
         }
     }
 
     pub fn view_center(&self) -> [f64; 2] {
         [
-            self.pan_control[0].state().pos,
-            self.pan_control[1].state().pos,
+            self.pan_control[0].position(),
+            self.pan_control[1].position(),
         ]
     }
 


### PR DESCRIPTION
Replace the "PD control with limits" implementation of the speed controller for the view window (explore mode) with a constant velocity controller. This is far simpler, and has the added benefit that it immediately stops when reaching the target or when the user releases the key. As a result, we no longer see a visual artifact of small changes in the image as the controller converges to the target.

The motivation for this change is that I want to add a "lazy render" check so that the fractal is only computed when the view port or other parameters change. This check is much more practical if we don't spend a bunch of time slowly converging to the target view on each user input.

First step toward implementing https://github.com/MatthewPeterKelly/fractal-renderer/issues/108.