### PR TITLE
Add `reset()` method in explore mode

### DIFF
--- a/src/cli/explore.rs
+++ b/src/cli/explore.rs
@@ -115,6 +115,16 @@ fn view_center_command_from_user_input(
     }
 }
 
+fn reset_command_from_key_press(input: &WinitInputHelper) -> bool {
+    if input.key_held(VirtualKeyCode::R) {
+        return true;
+    }
+    if input.key_pressed(VirtualKeyCode::R) {
+        return true;
+    }
+    false
+}
+
 /**
  * Create a simple GUI window that can be used to explore a fractal.
  * Supported features:
@@ -219,6 +229,12 @@ pub fn explore_fractal(params: &FractalParams, mut file_prefix: FilePrefix) -> R
                 }
             }
 
+            // Check for reset requests
+            if reset_command_from_key_press(&input) {
+                render_window.reset();
+            }
+
+            // Now do the hard rendering math:
             if render_window.update(
                 stopwatch.total_elapsed_seconds(),
                 center_command,

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -36,6 +36,12 @@ impl PointTracker {
         self.position
     }
 
+    /// Sets the position and clears any actively tracked target.
+    pub fn set_position(&mut self, position: f64) {
+        self.position = position;
+        self.target = Target::Velocity { vel_ref: 0.0 };
+    }
+
     pub fn update_and_return_pos(&mut self, time: f64) -> f64 {
         let delta_time = time - self.time;
         self.time += delta_time;

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -18,6 +18,9 @@ pub trait RenderWindow {
     /// Provides access to the current image specification for the window
     fn image_specification(&self) -> &ImageSpecification;
 
+    /// Resets the render window back to the view port that it was initialized with.
+    fn reset(&mut self);
+
     /// Recompute the entire fractal if any internal parameters have changed. This should be
     /// a no-op if called with no internal changes.
     ///
@@ -136,6 +139,11 @@ where
 {
     fn image_specification(&self) -> &ImageSpecification {
         self.view_control.image_specification()
+    }
+
+    fn reset(&mut self) {
+        self.view_control.reset();
+        self.render_required = true;
     }
 
     // TODO: consider a "fast update" that solves 2x2 or 3x3 pixel blocks while moving?

--- a/src/core/view_control.rs
+++ b/src/core/view_control.rs
@@ -114,6 +114,7 @@ pub fn compute_directional_max_velocity(direction: Vector2<f64>, max_speed: f64)
 pub struct ViewControl {
     // State:
     pub image_specification: ImageSpecification,
+    pub initial_image_specification: ImageSpecification,
 
     // Internal controllers:
     pub pan_control: [PointTracker; 2],
@@ -136,12 +137,21 @@ impl ViewControl {
     pub fn new(time: f64, image_specification: &ImageSpecification) -> Self {
         Self {
             image_specification: image_specification.clone(),
+            initial_image_specification: image_specification.clone(),
             pan_control: [
                 PointTracker::new(time, image_specification.center[0]),
                 PointTracker::new(time, image_specification.center[1]),
             ],
             zoom_control: PointTracker::new(time, image_specification.width.ln()),
         }
+    }
+
+    pub fn reset(&mut self) {
+        self.image_specification = self.initial_image_specification.clone();
+        self.pan_control[0].set_position(self.image_specification.center[0]);
+        self.pan_control[1].set_position(self.image_specification.center[1]);
+        self.zoom_control
+            .set_position(self.image_specification.width.ln());
     }
 
     pub fn view_center(&self) -> [f64; 2] {


### PR DESCRIPTION
Now, pressing "R" will reset the view port to the initial view.