### PR TITLE
Add "gallery" to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,18 @@ The binary produced by this project primarily supports two modes of operation:
 
 ## Gallery
 
-TODO
+**Driven-Damped Pendulum**
+
+Visualization of the basin of attraction for the driven-damped pendulum, where each period in the fractal is one full revolution of the pendulum. Source [here](https://github.com/MatthewPeterKelly/fractal-renderer/pull/130#issuecomment-2705358520).
+
+![ddp_QHD_with_antialias](https://github.com/user-attachments/assets/7af4ca16-7135-4a43-ae74-ee1985521130)
+
+**Barnsley Fern**
+
+Visualization of the Barnsley Fern, with the render settings tweaked so that it appears to be shadowed.
+Source [here](https://github.com/MatthewPeterKelly/fractal-renderer/pull/130#issuecomment-2705371473).
+
+![shadow_fern_QHD](https://github.com/user-attachments/assets/532b49f8-646c-48ea-8882-1644a98e105b)
 
 ## Status: Active Development
 


### PR DESCRIPTION
Add a collection of rendered fractal images to the README.

The image files are hosted directly on GitHub, rather than being committed directly to the repository. To make this work, each image in the gallery is added to this (or a future) PR as a comment, which includes both the image and the JSON. This has a nice side-effect: the images can always be regenerated by checking out the repository at the revision used in this PR and running the JSON command from the comment. Additionally, this means that we don't need to continually maintain every image in the gallery -- it is a snapshot in time (unlike the `examples/` directory, which is continually updated).