### PR TITLE
Update gallery images:  reduce resolution, add Mandelbrot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fractal Renderer
 
-A high-performance utility for rendering fractal images.
+A utility for quickly rendering high-quality fractal images.
 
 Currently this library supports five different fractals:
 
@@ -21,14 +21,14 @@ The binary produced by this project primarily supports two modes of operation:
 
 Visualization of the basin of attraction for the driven-damped pendulum, where each period in the fractal is one full revolution of the pendulum. Source [here](https://github.com/MatthewPeterKelly/fractal-renderer/pull/130#issuecomment-2705358520).
 
-![ddp_QHD_with_antialias](https://github.com/user-attachments/assets/7af4ca16-7135-4a43-ae74-ee1985521130)
+![driven-damped-pendulum-zoomed-out](https://github.com/user-attachments/assets/20dd0df6-aa3b-418a-a33c-bae1b765c9a3)
 
 **Barnsley Fern**
 
 Visualization of the Barnsley Fern, with the render settings tweaked so that it appears to be shadowed.
 Source [here](https://github.com/MatthewPeterKelly/fractal-renderer/pull/130#issuecomment-2705371473).
 
-![shadow_fern_QHD](https://github.com/user-attachments/assets/532b49f8-646c-48ea-8882-1644a98e105b)
+![barnsley-fern-shadow-version](https://github.com/user-attachments/assets/ce91830c-b539-4989-a267-fcb719b48e59)
 
 ## Status: Active Development
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Source [here](https://github.com/MatthewPeterKelly/fractal-renderer/pull/130#iss
 
 ![barnsley-fern-shadow-version](https://github.com/user-attachments/assets/ce91830c-b539-4989-a267-fcb719b48e59)
 
+**Mandelbrot Set**
+
+Visualization of the Mandelbrot Set with a dark blue color map and zoomed in a bit. Source [here](https://github.com/MatthewPeterKelly/fractal-renderer/pull/132#issuecomment-2706158399).
+
+![mandelbrot-zoomed-in-dark](https://github.com/user-attachments/assets/4addea8e-6bf9-44d1-be34-527fc5fa2883)
+
 ## Status: Active Development
 
 This library is under active development, with plans to add support for more fractals and features over time.

--- a/src/core/image_utils.rs
+++ b/src/core/image_utils.rs
@@ -169,7 +169,7 @@ pub fn scale_down_parameter_for_speed(lower_bound: f64, cached_value: f64, scale
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct RenderOptions {
     /// If set to a value larger than 1, it indicates that some pixels should be skipped
-    /// to allow for faster rendering. This is a particularily useful feature when trying
+    /// to allow for faster rendering. This is a particularly useful feature when trying
     /// to maintain a rapid frame-rate on larger images. It applies uniformly in both
     /// dimensions of the image. For example, setting this value to `3` will cause the
     /// image to be rendered in three-by-three blocks, with only one true "evaluation"


### PR DESCRIPTION
Follow-up to https://github.com/MatthewPeterKelly/fractal-renderer/pull/130, which added the gallery and described how it works.

Reduce the resolution so that the README loads faster.

Add an entry for the Mandelbrot set.