### PR TITLE
Make interpolation utilities generic (pull out of color map; add tests)

### DIFF
--- a/src/cli/color_swatch.rs
+++ b/src/cli/color_swatch.rs
@@ -3,7 +3,11 @@ use serde::{Deserialize, Serialize};
 use crate::core::{
     color_map::{
         with_uniform_spacing, ColorMap, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper,
-    }, file_io::{serialize_to_json_or_panic, FilePrefix}, image_utils::write_image_to_file_or_panic, interpolation::{LinearInterpolator, StepInterpolator}, stopwatch::Stopwatch
+    },
+    file_io::{serialize_to_json_or_panic, FilePrefix},
+    image_utils::write_image_to_file_or_panic,
+    interpolation::{LinearInterpolator, StepInterpolator},
+    stopwatch::Stopwatch,
 };
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/cli/color_swatch.rs
+++ b/src/cli/color_swatch.rs
@@ -3,11 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::{
     color_map::{
         with_uniform_spacing, ColorMap, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper,
-        LinearInterpolator, StepInterpolator,
-    },
-    file_io::{serialize_to_json_or_panic, FilePrefix},
-    image_utils::write_image_to_file_or_panic,
-    stopwatch::Stopwatch,
+    }, file_io::{serialize_to_json_or_panic, FilePrefix}, image_utils::write_image_to_file_or_panic, interpolation::{LinearInterpolator, StepInterpolator}, stopwatch::Stopwatch
 };
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -20,7 +20,6 @@ pub trait ColorMapper {
     fn compute_pixel(&self, query: f32) -> image::Rgb<u8>;
 }
 
-
 /**
  * Simple implementation of a "piecewise linear" color map, where the colors
  * are represented by simple linear interpolation in RGB color space. This is
@@ -92,7 +91,7 @@ where
      * Evaluates the color map, modestly efficient for small numbers of
      * keyframes. Any query outside of [0,1] will be clamped.
      */
-    fn compute_raw(&self, query: f32) -> Vector3<f32> {
+    fn evaluate(&self, query: f32) -> Vector3<f32> {
         if query <= 0.0f32 {
             *self.rgb_colors.first().unwrap()
         } else if query >= 1.0f32 {
@@ -118,11 +117,10 @@ where
     F: Interpolator<f32, Vector3<f32>>,
 {
     fn compute_pixel(&self, query: f32) -> image::Rgb<u8> {
-               let color_rgb = self.compute_raw(query);
+        let color_rgb = self.evaluate(query);
         image::Rgb([color_rgb[0] as u8, color_rgb[1] as u8, color_rgb[2] as u8])
     }
 }
-
 
 /**
  * Create a new keyframe vector, using the same colors, but uniformly spaced queries.

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -88,11 +88,6 @@ where
         }
     }
 
-    pub fn compute_pixel(&self, query: f32) -> image::Rgb<u8> {
-        let color_rgb = self.compute_raw(query);
-        image::Rgb([color_rgb[0] as u8, color_rgb[1] as u8, color_rgb[2] as u8])
-    }
-
     /**
      * Evaluates the color map, modestly efficient for small numbers of
      * keyframes. Any query outside of [0,1] will be clamped.
@@ -123,7 +118,8 @@ where
     F: Interpolator<f32, Vector3<f32>>,
 {
     fn compute_pixel(&self, query: f32) -> image::Rgb<u8> {
-        self.compute_pixel(query)
+               let color_rgb = self.compute_raw(query);
+        image::Rgb([color_rgb[0] as u8, color_rgb[1] as u8, color_rgb[2] as u8])
     }
 }
 

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -3,7 +3,8 @@ use iter_num_tools::lin_space;
 use nalgebra::Vector3;
 use serde::{Deserialize, Serialize};
 
-use super::lookup_table::LookupTable;
+use crate::core::interpolation::Interpolator;
+use crate::core::lookup_table::LookupTable;
 
 /**
  * Represents a single "keyframe" of the color map, pairing a
@@ -18,14 +19,7 @@ pub struct ColorMapKeyFrame {
 pub trait ColorMapper {
     fn compute_pixel(&self, query: f32) -> image::Rgb<u8>;
 }
-pub trait Interpolator {
-    fn interpolate(
-        &self,
-        query: f32,
-        value_zero: &Vector3<f32>,
-        value_one: &Vector3<f32>,
-    ) -> Vector3<f32>;
-}
+
 
 /**
  * Simple implementation of a "piecewise linear" color map, where the colors
@@ -127,39 +121,6 @@ where
     }
 }
 
-#[derive(Default)]
-pub struct StepInterpolator {
-    pub threshold: f32,
-}
-
-impl Interpolator for StepInterpolator {
-    fn interpolate(
-        &self,
-        query: f32,
-        value_zero: &Vector3<f32>,
-        value_one: &Vector3<f32>,
-    ) -> Vector3<f32> {
-        if query > self.threshold {
-            *value_one
-        } else {
-            *value_zero
-        }
-    }
-}
-
-#[derive(Default)]
-pub struct LinearInterpolator {}
-
-impl Interpolator for LinearInterpolator {
-    fn interpolate(
-        &self,
-        query: f32,
-        value_zero: &Vector3<f32>,
-        value_one: &Vector3<f32>,
-    ) -> Vector3<f32> {
-        value_zero + (value_one - value_zero) * query
-    }
-}
 
 /**
  * Create a new keyframe vector, using the same colors, but uniformly spaced queries.

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -20,6 +20,9 @@ pub trait ColorMapper {
     fn compute_pixel(&self, query: f32) -> image::Rgb<u8>;
 }
 
+
+// TODO:  make this generic and move over to interpolation!
+
 /**
  * Simple implementation of a "piecewise linear" color map, where the colors
  * are represented by simple linear interpolation in RGB color space. This is

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -41,6 +41,15 @@ where
     F: Interpolator<f32, Vector3<f32>>,
 {
     pub fn new(keyframes: &[ColorMapKeyFrame], interpolator: F) -> Self {
+        assert!(!keyframes.is_empty(), "keyframes must not be empty");
+        assert!(
+            keyframes.first().unwrap().query == 0.0,
+            "first keyframe query must be 0.0"
+        );
+        assert!(
+            keyframes.last().unwrap().query == 1.0,
+            "last keyframe query must be 1.0"
+        );
         let internal_keyframes: Vec<InterpolationKeyframe<f32, Vector3<f32>>> = keyframes
             .iter()
             .map(|kf| InterpolationKeyframe {

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -29,13 +29,19 @@ pub trait ColorMapper {
  * - https://github.com/MatthewPeterKelly/fractal-renderer/pull/71
  * - https://docs.rs/palette/latest/palette/
  */
-pub struct ColorMap<F: Interpolator> {
+pub struct ColorMap<F>
+where
+    F: Interpolator<f32, Vector3<f32>>,
+{
     queries: Vec<f32>,
-    rgb_colors: Vec<Vector3<f32>>, // [0,255], but as f32
+    rgb_colors: Vec<Vector3<f32>>,
     interpolator: F,
 }
 
-impl<F: Interpolator> ColorMap<F> {
+impl<F> ColorMap<F>
+where
+    F: Interpolator<f32, Vector3<f32>>,
+{
     /**
      * Create a color map from a vector of keyframes. The queries must be
      *
@@ -114,7 +120,7 @@ impl<F: Interpolator> ColorMap<F> {
 
 impl<F> ColorMapper for ColorMap<F>
 where
-    F: Interpolator,
+    F: Interpolator<f32, Vector3<f32>>,
 {
     fn compute_pixel(&self, query: f32) -> image::Rgb<u8> {
         self.compute_pixel(query)

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -27,8 +27,8 @@ pub trait ColorMapper {
  * practice. For details see:
  * - https://github.com/MatthewPeterKelly/fractal-renderer/pull/71
  * - https://docs.rs/palette/latest/palette/
+ *   The `ColorMap` struct is implemented as a KeyframeInterpolator
  */
-/// ColorMap is just a specific KeyframeInterpolator for f32 -> Vector3<f32>
 pub struct ColorMap<F>
 where
     F: Interpolator<f32, Vector3<f32>>,

--- a/src/core/histogram.rs
+++ b/src/core/histogram.rs
@@ -78,7 +78,7 @@ impl Histogram {
         } else {
             100.0 / (total as f32)
         };
-        writeln!(writer, "  total count: {}", total)?;
+        writeln!(writer, "  total count: {total}")?;
         for i in 0..self.bin_counts.len() {
             let count = self.bin_count(i);
             let percent = (count as f32) * percent_scale;

--- a/src/core/image_utils.rs
+++ b/src/core/image_utils.rs
@@ -198,11 +198,7 @@ impl SpeedOptimizer for RenderOptions {
     fn set_speed_optimization_level(&mut self, level: u32, cache: &Self::ReferenceCache) {
         self.downsample_stride = cache.downsample_stride + (level as usize);
 
-        self.subpixel_antialiasing = if cache.subpixel_antialiasing > level {
-            cache.subpixel_antialiasing - level
-        } else {
-            0
-        };
+        self.subpixel_antialiasing = cache.subpixel_antialiasing.saturating_sub(level);
     }
 }
 

--- a/src/core/image_utils.rs
+++ b/src/core/image_utils.rs
@@ -893,7 +893,7 @@ mod tests {
                 grid_mask.insert(n_grid, [i, j]);
             }
         }
-        assert_eq!(grid_mask.count_ones() as u32, n_grid * n_grid);
+        assert_eq!({ grid_mask.count_ones() }, n_grid * n_grid);
     }
 
     #[test]
@@ -971,12 +971,12 @@ mod tests {
             );
 
             // Now let the "full vector" machinery figure out the pixels
-            assert_eq!(interpolator.interpolate(&data_view, 1), Rgb([10, 0, 20]));
-            assert_eq!(interpolator.interpolate(&data_view, 3), Rgb([20, 0, 0]));
+            assert_eq!(interpolator.interpolate(data_view, 1), Rgb([10, 0, 20]));
+            assert_eq!(interpolator.interpolate(data_view, 3), Rgb([20, 0, 0]));
 
             // We don't expect to query at known points, but lets make sure it doesn't break
-            assert_eq!(interpolator.interpolate(&data_view, 0), Rgb([0, 0, 40]));
-            assert_eq!(interpolator.interpolate(&data_view, 2), Rgb([20, 0, 0]));
+            assert_eq!(interpolator.interpolate(data_view, 0), Rgb([0, 0, 40]));
+            assert_eq!(interpolator.interpolate(data_view, 2), Rgb([20, 0, 0]));
         }
         {
             // Now, let's add more data and try again:
@@ -987,19 +987,19 @@ mod tests {
             let interpolator = KeyframeLinearPixelInerpolation::new(data.len(), downsample_stride);
 
             // Check the first points again, but now, expect the index 3 to properly interpolate
-            assert_eq!(interpolator.interpolate(&data_view, 1), Rgb([10, 0, 20]));
-            assert_eq!(interpolator.interpolate(&data_view, 3), Rgb([10, 30, 0]));
+            assert_eq!(interpolator.interpolate(data_view, 1), Rgb([10, 0, 20]));
+            assert_eq!(interpolator.interpolate(data_view, 3), Rgb([10, 30, 0]));
             // Check the keyframes again, as well:
-            assert_eq!(interpolator.interpolate(&data_view, 0), Rgb([0, 0, 40]));
-            assert_eq!(interpolator.interpolate(&data_view, 2), Rgb([20, 0, 0]));
-            assert_eq!(interpolator.interpolate(&data_view, 4), Rgb([0, 60, 0]));
+            assert_eq!(interpolator.interpolate(data_view, 0), Rgb([0, 0, 40]));
+            assert_eq!(interpolator.interpolate(data_view, 2), Rgb([20, 0, 0]));
+            assert_eq!(interpolator.interpolate(data_view, 4), Rgb([0, 60, 0]));
         }
     }
 
     #[test]
     fn test_linear_pixel_interpolation_stride_3() {
         let downsample_stride: usize = 3;
-        let data = vec![
+        let data = [
             Rgb([0, 0, 33]),
             Rgb([123, 123, 123]), // dummy data, should never be read
             Rgb([123, 123, 123]), // dummy data, should never be read
@@ -1008,7 +1008,7 @@ mod tests {
             Rgb([123, 123, 123]), // dummy data, should never be read
             Rgb([81, 140, 15]),
             Rgb([123, 123, 123]), // dummy data, should never be read
-            Rgb([123, 123, 123]), // dummy data, should never be read
+            Rgb([123, 123, 123]),
         ];
 
         let interpolator = KeyframeLinearPixelInerpolation::new(data.len(), downsample_stride);
@@ -1016,18 +1016,18 @@ mod tests {
         let data_view = |index: usize| -> &Rgb<u8> { &data[index] };
 
         // Check interpolated points
-        assert_eq!(interpolator.interpolate(&data_view, 1), Rgb([30, 20, 22]));
-        assert_eq!(interpolator.interpolate(&data_view, 2), Rgb([60, 40, 11]));
-        assert_eq!(interpolator.interpolate(&data_view, 4), Rgb([87, 86, 5]));
-        assert_eq!(interpolator.interpolate(&data_view, 5), Rgb([84, 113, 10]));
+        assert_eq!(interpolator.interpolate(data_view, 1), Rgb([30, 20, 22]));
+        assert_eq!(interpolator.interpolate(data_view, 2), Rgb([60, 40, 11]));
+        assert_eq!(interpolator.interpolate(data_view, 4), Rgb([87, 86, 5]));
+        assert_eq!(interpolator.interpolate(data_view, 5), Rgb([84, 113, 10]));
 
         // Check extrapolated points
-        assert_eq!(interpolator.interpolate(&data_view, 7), Rgb([81, 140, 15]));
-        assert_eq!(interpolator.interpolate(&data_view, 8), Rgb([81, 140, 15]));
+        assert_eq!(interpolator.interpolate(data_view, 7), Rgb([81, 140, 15]));
+        assert_eq!(interpolator.interpolate(data_view, 8), Rgb([81, 140, 15]));
 
         // Check keyframe points
-        assert_eq!(interpolator.interpolate(&data_view, 0), Rgb([0, 0, 33]));
-        assert_eq!(interpolator.interpolate(&data_view, 3), Rgb([90, 60, 0]));
-        assert_eq!(interpolator.interpolate(&data_view, 6), Rgb([81, 140, 15]));
+        assert_eq!(interpolator.interpolate(data_view, 0), Rgb([0, 0, 33]));
+        assert_eq!(interpolator.interpolate(data_view, 3), Rgb([90, 60, 0]));
+        assert_eq!(interpolator.interpolate(data_view, 6), Rgb([81, 140, 15]));
     }
 }

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -1,47 +1,45 @@
-use nalgebra::Vector3;
+use std::ops::{Add, Mul, Sub};
+use num_traits::Float;
 
-pub trait Interpolator {
-    fn interpolate(
-        &self,
-        query: f32,
-        value_zero: &Vector3<f32>,
-        value_one: &Vector3<f32>,
-    ) -> Vector3<f32>;
+/// Trait for interpolation between two values
+pub trait Interpolator<T, V>
+where
+    T: Float + Copy,
+    V: Copy + Add<Output = V> + Sub<Output = V> + Mul<T, Output = V>,
+{
+    fn interpolate(&self, alpha: T, a: &V, b: &V) -> V;
 }
 
-
+/// Step interpolator switches from a to b at a threshold
 #[derive(Default)]
-pub struct StepInterpolator {
-    pub threshold: f32,
+pub struct StepInterpolator<T: Float + Copy> {
+    pub threshold: T,
 }
 
-impl Interpolator for StepInterpolator {
-    fn interpolate(
-        &self,
-        query: f32,
-        value_zero: &Vector3<f32>,
-        value_one: &Vector3<f32>,
-    ) -> Vector3<f32> {
-        if query > self.threshold {
-            *value_one
+impl<T, V> Interpolator<T, V> for StepInterpolator<T>
+where
+    T: Float + Copy,
+    V: Copy + Add<Output = V> + Sub<Output = V> + Mul<T, Output = V>,
+{
+    fn interpolate(&self, alpha: T, a: &V, b: &V) -> V {
+        if alpha > self.threshold {
+            *b
         } else {
-            *value_zero
+            *a
         }
     }
 }
 
+/// Linear interpolation: a * (1 - alpha) + b * alpha
 #[derive(Default)]
-pub struct LinearInterpolator {}
+pub struct LinearInterpolator;
 
-impl Interpolator for LinearInterpolator {
-    fn interpolate(
-        &self,
-        query: f32,
-        value_zero: &Vector3<f32>,
-        value_one: &Vector3<f32>,
-    ) -> Vector3<f32> {
-        value_zero + (value_one - value_zero) * query
+impl<T, V> Interpolator<T, V> for LinearInterpolator
+where
+    T: Float + Copy,
+    V: Copy + Add<Output = V> + Sub<Output = V> + Mul<T, Output = V>,
+{
+    fn interpolate(&self, alpha: T, a: &V, b: &V) -> V {
+        *a + (*b - *a) * alpha
     }
 }
-
-

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -1,5 +1,5 @@
-use std::ops::{Add, Mul, Sub};
 use num_traits::Float;
+use std::ops::{Add, Mul, Sub};
 
 /// Trait for interpolation between two values
 pub trait Interpolator<T, V>

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -1,0 +1,47 @@
+use nalgebra::Vector3;
+
+pub trait Interpolator {
+    fn interpolate(
+        &self,
+        query: f32,
+        value_zero: &Vector3<f32>,
+        value_one: &Vector3<f32>,
+    ) -> Vector3<f32>;
+}
+
+
+#[derive(Default)]
+pub struct StepInterpolator {
+    pub threshold: f32,
+}
+
+impl Interpolator for StepInterpolator {
+    fn interpolate(
+        &self,
+        query: f32,
+        value_zero: &Vector3<f32>,
+        value_one: &Vector3<f32>,
+    ) -> Vector3<f32> {
+        if query > self.threshold {
+            *value_one
+        } else {
+            *value_zero
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct LinearInterpolator {}
+
+impl Interpolator for LinearInterpolator {
+    fn interpolate(
+        &self,
+        query: f32,
+        value_zero: &Vector3<f32>,
+        value_one: &Vector3<f32>,
+    ) -> Vector3<f32> {
+        value_zero + (value_one - value_zero) * query
+    }
+}
+
+

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -38,11 +38,12 @@ where
 {
     pub fn new(keyframes: Vec<InterpolationKeyframe<T, V>>, interpolator: F) -> Self {
         assert!(!keyframes.is_empty(), "keyframes must not be empty");
-        assert!(keyframes.first().unwrap().input == T::zero(), "first keyframe input must be 0.0");
-        assert!(keyframes.last().unwrap().input == T::one(), "last keyframe input must be 1.0");
 
         for pair in keyframes.windows(2) {
-            assert!(pair[0].input < pair[1].input, "keyframes must be strictly increasing");
+            assert!(
+                pair[0].input < pair[1].input,
+                "keyframes must be strictly increasing"
+            );
         }
 
         let queries = keyframes.iter().map(|k| k.input).collect();
@@ -55,21 +56,23 @@ where
         }
     }
 
+    /// Evaluates the value of the trajectory by interpolating between keyframes.
+    /// The query will be clamped to the valid domain of the keyframes (no extrapolation).
     pub fn evaluate(&self, query: T) -> V {
-        if query <= T::zero() {
+        if query <= *self.queries.first().unwrap() {
             self.values.first().copied().unwrap()
-        } else if query >= T::one() {
+        } else if query >= *self.queries.last().unwrap() {
             self.values.last().copied().unwrap()
         } else {
             let idx_upp = self.queries.partition_point(|q| query >= *q);
             let idx_low = idx_upp - 1;
             let val_low = self.queries[idx_low];
             let alpha = (query - val_low) / (self.queries[idx_upp] - val_low);
-            self.interpolator.interpolate(alpha, &self.values[idx_low], &self.values[idx_upp])
+            self.interpolator
+                .interpolate(alpha, &self.values[idx_low], &self.values[idx_upp])
         }
     }
 }
-
 
 /// Step interpolator switches from a to b at a threshold
 #[derive(Default)]
@@ -92,6 +95,7 @@ where
 }
 
 /// Linear interpolation: a * (1 - alpha) + b * alpha
+/// Extrapolate if alpha is not in [0,1]
 #[derive(Default)]
 pub struct LinearInterpolator;
 
@@ -102,5 +106,150 @@ where
 {
     fn interpolate(&self, alpha: T, a: &V, b: &V) -> V {
         *a + (*b - *a) * alpha
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use nalgebra::Vector3;
+
+    #[test]
+    fn test_linear_interpolator_scalar() {
+        let interp = LinearInterpolator;
+        let a: f32 = 10.0;
+        let b: f32 = 20.0;
+        // Keyframes
+        assert_relative_eq!(interp.interpolate(0.0, &a, &b), 10.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.interpolate(1.0, &a, &b), 20.0, epsilon = 1e-6);
+        // interpolation and extrapolation
+        assert_relative_eq!(interp.interpolate(0.5, &a, &b), 15.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.interpolate(1.5, &a, &b), 25.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_step_interpolator_scalar() {
+        let interp = StepInterpolator { threshold: 0.5 };
+        let a: f64 = 1.0;
+        let b: f64 = 5.0;
+        assert_eq!(interp.interpolate(-0.5, &a, &b), 1.0);
+        assert_eq!(interp.interpolate(0.0, &a, &b), 1.0);
+        assert_eq!(interp.interpolate(0.49999, &a, &b), 1.0);
+        assert_eq!(interp.interpolate(0.5, &a, &b), 1.0);
+        assert_eq!(interp.interpolate(0.50001, &a, &b), 5.0);
+        assert_eq!(interp.interpolate(1.0, &a, &b), 5.0);
+        assert_eq!(interp.interpolate(1.5, &a, &b), 5.0);
+    }
+
+    #[test]
+    fn test_linear_interpolator_vector() {
+        let interp = LinearInterpolator;
+        let a = Vector3::new(-5.0_f32, 2.0, 6.0);
+        let b = Vector3::new(10.0_f32, 20.0, 30.0);
+        assert_relative_eq!(
+            interp.interpolate(0.0, &a, &b),
+            a,
+            epsilon = 1e-6
+        );
+        assert_relative_eq!(
+            interp.interpolate(1.0, &a, &b),
+            b,
+            epsilon = 1e-6
+        );
+        assert_relative_eq!(
+            interp.interpolate(0.3, &a, &b),
+            0.3 * a + 0.7 * b,
+            epsilon = 1e-6
+        );
+    }
+
+    #[test]
+    fn test_keyframe_interpolator_scalar_linear() {
+        let keyframes: Vec<InterpolationKeyframe<f32, f32>> = vec![
+            InterpolationKeyframe {
+                input: -2.0,
+                output: 1.0,
+            },
+            InterpolationKeyframe {
+                input: 2.0,
+                output: 11.0,
+            },
+            InterpolationKeyframe {
+                input: 6.0,
+                output: 12.0,
+            },
+        ];
+        let interp = KeyframeInterpolator::new(keyframes, LinearInterpolator);
+        assert_relative_eq!(interp.evaluate(-6.0), 1.0, epsilon = 1e-6); // extrapolate (clamped)
+        assert_relative_eq!(interp.evaluate(-2.0), 1.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.evaluate(1.0), 8.5, epsilon = 1e-6); // interpolate
+        assert_relative_eq!(interp.evaluate(2.0), 11.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.evaluate(3.0), 11.25, epsilon = 1e-6); // interpolate
+        assert_relative_eq!(interp.evaluate(6.0), 12.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.evaluate(8.0), 12.0, epsilon = 1e-6); // extrapolate (clamped)
+    }
+
+    #[test]
+    fn test_keyframe_interpolator_vector_linear() {
+        let low = Vector3::new(10.0, 3.0, 4.0);
+        let upp = Vector3::new(100.0, 50.0, -30.0);
+        let keyframes: Vec<InterpolationKeyframe<f32, Vector3<f32>>> = vec![
+            InterpolationKeyframe {
+                input: -3.0,
+                output: low,
+            },
+            InterpolationKeyframe {
+                input: 9.0,
+                output: upp,
+            },
+        ];
+        let interp = KeyframeInterpolator::new(keyframes, LinearInterpolator);
+
+        assert_relative_eq!(interp.evaluate(-4.0), low, epsilon = 1e-6); // clamped extrapolate
+        assert_relative_eq!(interp.evaluate(-3.0), low, epsilon = 1e-6); // keyframe
+        assert_relative_eq!(
+            interp.evaluate(3.0),
+            0.5 * (low + upp),
+            epsilon = 1e-6
+        ); // interpolate
+        assert_relative_eq!(
+            interp.evaluate(6.0),
+            0.25 * low + 0.75 * upp,
+            epsilon = 1e-6
+        ); // interpolate
+        assert_relative_eq!(interp.evaluate(9.0), upp, epsilon = 1e-6); // keyframe
+        assert_relative_eq!(interp.evaluate(100.0), low, epsilon = 1e-6); // clamped extrapolate
+    }
+
+    #[test]
+    #[should_panic(expected = "keyframes must not be empty")]
+    fn test_empty_keyframe_panics() {
+        let _ = KeyframeInterpolator::<f32, f32, _>::new(vec![], LinearInterpolator);
+    }
+
+    #[test]
+    #[should_panic(expected = "keyframes must be strictly increasing")]
+    fn test_non_monotonic_keyframes_panics() {
+        let keyframes = vec![
+            InterpolationKeyframe {
+                input: 0.0f32,
+                output: 1.0,
+            },
+            InterpolationKeyframe {
+                input: 0.5,
+                output: 2.0,
+            },
+            InterpolationKeyframe {
+                input: 0.5,
+                output: 3.0,
+            },
+            InterpolationKeyframe {
+                input: 1.0,
+                output: 4.0,
+            },
+        ];
+        let _ = KeyframeInterpolator::new(keyframes, LinearInterpolator);
     }
 }

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -10,6 +10,67 @@ where
     fn interpolate(&self, alpha: T, a: &V, b: &V) -> V;
 }
 
+/// Keyframes, used to construct (and define) a piecewise interpolator
+/// Generic keyframe: maps an input (query) to an output value.
+#[derive(Clone, Copy)]
+pub struct InterpolationKeyframe<T, V> {
+    pub input: T,
+    pub output: V,
+}
+
+/// Generic container for performing interpolation between keyframes
+pub struct KeyframeInterpolator<T, V, F>
+where
+    T: Float + Copy,
+    V: Copy + Add<Output = V> + Sub<Output = V> + Mul<T, Output = V>,
+    F: Interpolator<T, V>,
+{
+    queries: Vec<T>,
+    values: Vec<V>,
+    interpolator: F,
+}
+
+impl<T, V, F> KeyframeInterpolator<T, V, F>
+where
+    T: Float + Copy,
+    V: Copy + Add<Output = V> + Sub<Output = V> + Mul<T, Output = V>,
+    F: Interpolator<T, V>,
+{
+    pub fn new(keyframes: Vec<InterpolationKeyframe<T, V>>, interpolator: F) -> Self {
+        assert!(!keyframes.is_empty(), "keyframes must not be empty");
+        assert!(keyframes.first().unwrap().input == T::zero(), "first keyframe input must be 0.0");
+        assert!(keyframes.last().unwrap().input == T::one(), "last keyframe input must be 1.0");
+
+        for pair in keyframes.windows(2) {
+            assert!(pair[0].input < pair[1].input, "keyframes must be strictly increasing");
+        }
+
+        let queries = keyframes.iter().map(|k| k.input).collect();
+        let values = keyframes.iter().map(|k| k.output).collect();
+
+        Self {
+            queries,
+            values,
+            interpolator,
+        }
+    }
+
+    pub fn evaluate(&self, query: T) -> V {
+        if query <= T::zero() {
+            self.values.first().copied().unwrap()
+        } else if query >= T::one() {
+            self.values.last().copied().unwrap()
+        } else {
+            let idx_upp = self.queries.partition_point(|q| query >= *q);
+            let idx_low = idx_upp - 1;
+            let val_low = self.queries[idx_low];
+            let alpha = (query - val_low) / (self.queries[idx_upp] - val_low);
+            self.interpolator.interpolate(alpha, &self.values[idx_low], &self.values[idx_upp])
+        }
+    }
+}
+
+
 /// Step interpolator switches from a to b at a threshold
 #[derive(Default)]
 pub struct StepInterpolator<T: Float + Copy> {

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -74,7 +74,7 @@ where
     }
 }
 
-/// Step interpolator switches from a to b at a threshold
+/// Step interpolator switches from the lower to upper value above the specified threshold
 #[derive(Default)]
 pub struct StepInterpolator<T: Float + Copy> {
     pub threshold: T,
@@ -85,11 +85,11 @@ where
     T: Float + Copy,
     V: Copy + Add<Output = V> + Sub<Output = V> + Mul<T, Output = V>,
 {
-    fn interpolate(&self, alpha: T, a: &V, b: &V) -> V {
+    fn interpolate(&self, alpha: T, low: &V, upp: &V) -> V {
         if alpha > self.threshold {
-            *b
+            *upp
         } else {
-            *a
+            *low
         }
     }
 }
@@ -104,8 +104,8 @@ where
     T: Float + Copy,
     V: Copy + Add<Output = V> + Sub<Output = V> + Mul<T, Output = V>,
 {
-    fn interpolate(&self, alpha: T, a: &V, b: &V) -> V {
-        *a + (*b - *a) * alpha
+    fn interpolate(&self, alpha: T, low: &V, upp: &V) -> V {
+        *low + (*upp - *low) * alpha
     }
 }
 
@@ -119,28 +119,28 @@ mod tests {
     #[test]
     fn test_linear_interpolator_scalar() {
         let interp = LinearInterpolator;
-        let a: f32 = 10.0;
-        let b: f32 = 20.0;
+        let low: f32 = 10.0;
+        let upp: f32 = 20.0;
         // Keyframes
-        assert_relative_eq!(interp.interpolate(0.0, &a, &b), 10.0, epsilon = 1e-6);
-        assert_relative_eq!(interp.interpolate(1.0, &a, &b), 20.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.interpolate(0.0, &low, &upp), 10.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.interpolate(1.0, &low, &upp), 20.0, epsilon = 1e-6);
         // interpolation and extrapolation
-        assert_relative_eq!(interp.interpolate(0.5, &a, &b), 15.0, epsilon = 1e-6);
-        assert_relative_eq!(interp.interpolate(1.5, &a, &b), 25.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.interpolate(0.5, &low, &upp), 15.0, epsilon = 1e-6);
+        assert_relative_eq!(interp.interpolate(1.5, &low, &upp), 25.0, epsilon = 1e-6);
     }
 
     #[test]
     fn test_step_interpolator_scalar() {
         let interp = StepInterpolator { threshold: 0.5 };
-        let a: f64 = 1.0;
-        let b: f64 = 5.0;
-        assert_eq!(interp.interpolate(-0.5, &a, &b), 1.0);
-        assert_eq!(interp.interpolate(0.0, &a, &b), 1.0);
-        assert_eq!(interp.interpolate(0.49999, &a, &b), 1.0);
-        assert_eq!(interp.interpolate(0.5, &a, &b), 1.0);
-        assert_eq!(interp.interpolate(0.50001, &a, &b), 5.0);
-        assert_eq!(interp.interpolate(1.0, &a, &b), 5.0);
-        assert_eq!(interp.interpolate(1.5, &a, &b), 5.0);
+        let low: f64 = 1.0;
+        let upp: f64 = 5.0;
+        assert_eq!(interp.interpolate(-0.5, &low, &upp), 1.0);
+        assert_eq!(interp.interpolate(0.0, &low, &upp), 1.0);
+        assert_eq!(interp.interpolate(0.49999, &low, &upp), 1.0);
+        assert_eq!(interp.interpolate(0.5, &low, &upp), 1.0);
+        assert_eq!(interp.interpolate(0.50001, &low, &upp), 5.0);
+        assert_eq!(interp.interpolate(1.0, &low, &upp), 5.0);
+        assert_eq!(interp.interpolate(1.5, &low, &upp), 5.0);
     }
 
     #[test]

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -146,21 +146,13 @@ mod tests {
     #[test]
     fn test_linear_interpolator_vector() {
         let interp = LinearInterpolator;
-        let a = Vector3::new(-5.0_f32, 2.0, 6.0);
-        let b = Vector3::new(10.0_f32, 20.0, 30.0);
+        let low = Vector3::new(-5.0_f32, 2.0, 6.0);
+        let upp = Vector3::new(10.0_f32, 20.0, 30.0);
+        assert_relative_eq!(interp.interpolate(0.0, &low, &upp), low, epsilon = 1e-6);
+        assert_relative_eq!(interp.interpolate(1.0, &low, &upp), upp, epsilon = 1e-6);
         assert_relative_eq!(
-            interp.interpolate(0.0, &a, &b),
-            a,
-            epsilon = 1e-6
-        );
-        assert_relative_eq!(
-            interp.interpolate(1.0, &a, &b),
-            b,
-            epsilon = 1e-6
-        );
-        assert_relative_eq!(
-            interp.interpolate(0.3, &a, &b),
-            0.3 * a + 0.7 * b,
+            interp.interpolate(0.3, &low, &upp),
+            0.7 * low + 0.3 * upp,
             epsilon = 1e-6
         );
     }
@@ -209,18 +201,14 @@ mod tests {
 
         assert_relative_eq!(interp.evaluate(-4.0), low, epsilon = 1e-6); // clamped extrapolate
         assert_relative_eq!(interp.evaluate(-3.0), low, epsilon = 1e-6); // keyframe
-        assert_relative_eq!(
-            interp.evaluate(3.0),
-            0.5 * (low + upp),
-            epsilon = 1e-6
-        ); // interpolate
+        assert_relative_eq!(interp.evaluate(3.0), 0.5 * (low + upp), epsilon = 1e-6); // interpolate
         assert_relative_eq!(
             interp.evaluate(6.0),
             0.25 * low + 0.75 * upp,
             epsilon = 1e-6
         ); // interpolate
         assert_relative_eq!(interp.evaluate(9.0), upp, epsilon = 1e-6); // keyframe
-        assert_relative_eq!(interp.evaluate(100.0), low, epsilon = 1e-6); // clamped extrapolate
+        assert_relative_eq!(interp.evaluate(100.0), upp, epsilon = 1e-6); // clamped extrapolate
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod dynamical_systems;
 pub mod file_io;
 pub mod histogram;
 pub mod image_utils;
+pub mod interpolation;
 pub mod lookup_table;
 pub mod ode_solvers;
 pub mod render_window;

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -212,7 +212,7 @@ where
 
         serialize_to_json_or_panic(
             self.file_prefix
-                .full_path_with_suffix(&format!("_{}.json", datetime)),
+                .full_path_with_suffix(&format!("_{datetime}.json")),
             &self.image_specification(),
         );
 
@@ -230,7 +230,7 @@ where
 
         write_image_to_file_or_panic(
             self.file_prefix
-                .full_path_with_suffix(&format!("_{}.png", datetime)),
+                .full_path_with_suffix(&format!("_{datetime}.png")),
             |f| imgbuf.save(f),
         );
     }

--- a/src/core/view_control.rs
+++ b/src/core/view_control.rs
@@ -210,7 +210,7 @@ impl ViewControl {
                     });
                 }
             }
-            CenterCommand::Idle {} => {
+            CenterCommand::Idle() => {
                 for ctrl in &mut self.pan_control {
                     ctrl.set_idle_target();
                 }

--- a/src/fractals/quadratic_map.rs
+++ b/src/fractals/quadratic_map.rs
@@ -4,12 +4,12 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
 
 use crate::core::{
-    color_map::{ColorMap, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper, LinearInterpolator},
+    color_map::{ColorMap, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper},
     histogram::{CumulativeDistributionFunction, Histogram},
     image_utils::{
         scale_down_parameter_for_speed, ImageSpecification, PixelMapper, RenderOptions, Renderable,
         SpeedOptimizer,
-    },
+    }, interpolation::LinearInterpolator,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/fractals/quadratic_map.rs
+++ b/src/fractals/quadratic_map.rs
@@ -9,7 +9,8 @@ use crate::core::{
     image_utils::{
         scale_down_parameter_for_speed, ImageSpecification, PixelMapper, RenderOptions, Renderable,
         SpeedOptimizer,
-    }, interpolation::LinearInterpolator,
+    },
+    interpolation::LinearInterpolator,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
Refactors the color map utilities so that it depends on a general purpose keyframe interpolation library. This library will then be used by a follow-up PR. Also adds a bunch of new tests to cover the interpolation library core utilities.