### PR TITLE
Add support for keyframe modification to the keyframe interpolator

### DIFF
--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -53,8 +53,8 @@ where
         let internal_keyframes: Vec<InterpolationKeyframe<f32, Vector3<f32>>> = keyframes
             .iter()
             .map(|kf| InterpolationKeyframe {
-                input: kf.query,
-                output: Vector3::new(
+                query: kf.query,
+                value: Vector3::new(
                     kf.rgb_raw[0] as f32,
                     kf.rgb_raw[1] as f32,
                     kf.rgb_raw[2] as f32,

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -62,7 +62,7 @@ where
     pub fn set_keyframe_query(&mut self, index: usize, query: T) {
         assert!(
             index < self.queries.len(),
-            "Index out of bounds!  Cannot update keyframe input."
+            "Index out of bounds!  Cannot update keyframe query."
         );
         if index > 0 {
             assert!(
@@ -83,7 +83,7 @@ where
     pub fn set_keyframe_value(&mut self, index: usize, value: V) {
         assert!(
             index < self.queries.len(),
-            "Index out of bounds!  Cannot update keyframe output."
+            "Index out of bounds!  Cannot update keyframe value."
         );
         // No need to check monotonicity for output values, as they can be any value.
         self.values[index] = value;
@@ -335,12 +335,42 @@ mod tests {
         interp.set_keyframe_value(1, 200.0);
         assert_relative_eq!(interp.evaluate(-1.0), 20.0, epsilon = 1e-6); // extrapolate (clamped)
         assert_relative_eq!(interp.evaluate(-0.0), 20.0, epsilon = 1e-6);
-
         assert_relative_eq!(interp.evaluate(3.0), 128.0, epsilon = 1e-6); // interpolate
         assert_relative_eq!(interp.evaluate(5.0), 200.0, epsilon = 1e-6);
         assert_relative_eq!(interp.evaluate(7.0), 120.0, epsilon = 1e-6); // interpolate
-
         assert_relative_eq!(interp.evaluate(10.0), 0.0, epsilon = 1e-6);
         assert_relative_eq!(interp.evaluate(18.0), 0.0, epsilon = 1e-6); // extrapolate (clamped)
+    }
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds!  Cannot update keyframe query.")]
+    fn test_keyframe_update_panic_query_bounds() {
+        let mut interp = make_test_scalar_interpolator();
+        interp.set_keyframe_query(10, 5.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds!  Cannot update keyframe value.")]
+    fn test_keyframe_update_panic_value_bounds() {
+        let mut interp = make_test_scalar_interpolator();
+        interp.set_keyframe_value(10, 5.0);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "The keyframes must remain strictly monotonic! Violation on lower edge."
+    )]
+    fn test_keyframe_update_panic_query_low_monotonic() {
+        let mut interp = make_test_scalar_interpolator();
+        interp.set_keyframe_query(1, -100.0);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "The keyframes must remain strictly monotonic! Violation on upper edge."
+    )]
+    fn test_keyframe_update_panic_query_upp_monotonic() {
+        let mut interp = make_test_scalar_interpolator();
+        interp.set_keyframe_query(1, 100.0);
     }
 }

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -19,6 +19,8 @@ pub struct InterpolationKeyframe<T, V> {
 }
 
 /// Generic container for performing interpolation between keyframes
+
+#[derive(Clone, Debug)]
 pub struct KeyframeInterpolator<T, V, F>
 where
     T: Float + Copy,
@@ -56,6 +58,29 @@ where
         }
     }
 
+    pub fn set_keyframe_query(&mut self, index: usize, input: T) {
+        assert!(index < self.queries.len(), "Index out of bounds!  Cannot update keyframe input.");
+        if index > 0 {
+            assert!(
+                self.queries[index - 1] < input,
+                "The keyframes must remain strictly monotonic! Violation on lower edge."
+            );
+        }
+        if index < (self.queries.len() - 1) {
+            assert!(
+                input < self.queries[index + 1],
+                "The keyframes must remain strictly monotonic! Violation on upper edge."
+            );
+        }
+        self.queries[index] = input;
+    }
+
+        pub fn set_keyframe_value(&mut self, index: usize, output: V) {
+        assert!(index < self.queries.len(), "Index out of bounds!  Cannot update keyframe output.");
+        // No need to check monotonicity for output values, as they can be any value.
+        self.values[index] = output;
+    }
+
     /// Evaluates the value of the trajectory by interpolating between keyframes.
     /// The query will be clamped to the valid domain of the keyframes (no extrapolation).
     pub fn evaluate(&self, query: T) -> V {
@@ -75,7 +100,7 @@ where
 }
 
 /// Step interpolator switches from the lower to upper value above the specified threshold
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct StepInterpolator<T: Float + Copy> {
     pub threshold: T,
 }
@@ -96,7 +121,7 @@ where
 
 /// Linear interpolation: a * (1 - alpha) + b * alpha
 /// Extrapolate if alpha is not in [0,1]
-#[derive(Default)]
+#[derive(Default, Clone, Copy, Debug)]
 pub struct LinearInterpolator;
 
 impl<T, V> Interpolator<T, V> for LinearInterpolator


### PR DESCRIPTION
Adds two new methods to the `KeyframeInterpolator`, enabling the user to modify both the query and value of a keyframe. For now, this feature is just covered by tests, but in a follow-up PR this will be used for adaptive frame rate regulation.

Also fix some naming inconsistency and extend test coverage for the two new methods.