### PR TITLE
Dynamically adjust render quality to track target frame rate in `explore` mode

### DIFF
--- a/examples/julia/default.json
+++ b/examples/julia/default.json
@@ -33,11 +33,11 @@
       "lookup_table_count": 2048,
       "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
-      "histogram_sample_count": 40000
+      "histogram_sample_count": 50000
     },
     "render_options": {
       "downsample_stride": 1,
-      "subpixel_antialiasing": 0
+      "subpixel_antialiasing": 3
     }
   }
 }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -187,8 +187,8 @@ impl InteractiveFrameRatePolicy {
         self.command = raw_command.clamp(Self::MIN_COMMAND, Self::MAX_COMMAND);
 
         println!(
-            "Evaluating policy: measured_period = {:.6}, command = {:.6} -> {:.6}",
-            measured_period, prev_cmd, self.command
+            "Evaluating policy: measured_period = {:.6}, command = {:.6} -> {:.6} -> {:.6}",
+            measured_period, prev_cmd, raw_command, self.command
         ); // HACK!!! Remove this in production code.
 
         self.command
@@ -325,7 +325,7 @@ mod tests {
 
 
 
-    /// Model that maps from a command to a period, enulating the I/O behavior of the full
+    /// Model that maps from a command to a period, emulating the I/O behavior of the full
     /// render pipeline. The "fast" variant will emulate a system that always renders faster
     /// than the target period, regardless of the command. It does however satisfy the requirement
     /// that a higher command will always yield a shorter period.
@@ -371,18 +371,18 @@ mod tests {
             let next_command = policy.evaluate_policy(prev_period);
             let next_period = render_proxy.evaluate(next_command);
 
-            println!(
-                "Prev Command: {:.6}, Prev Period: {:.6}, Next Command: {:.6}, Next Period: {:.6}",
-                prev_command, prev_period, next_command, next_period
-            );  // HACK!!!
+            // println!(
+            //     "Prev Command: {:.6}, Prev Period: {:.6}, Next Command: {:.6}, Next Period: {:.6}",
+            //     prev_command, prev_period, next_command, next_period
+            // );  // HACK!!!
 
             let prev_cmd_err = (prev_command - steady_state_command).abs();
             let next_cmd_err = (next_command - steady_state_command).abs();
-            // assert_le!(next_cmd_err, prev_cmd_err);
+            assert_le!(next_cmd_err, prev_cmd_err);
 
             let prev_period_err = (prev_period - steady_state_period).abs();
             let next_period_err = (next_period - steady_state_period).abs();
-            // assert_le!(next_period_err, prev_period_err);
+            assert_le!(next_period_err, prev_period_err);
 
             // println!(
             //     "Prev Command Error: {:.6}, Next Command Error: {:.6}, Prev Period Error: {:.6}, Next Period Error: {:.6}",
@@ -408,7 +408,7 @@ mod tests {
         let steady_state_command = InteractiveFrameRatePolicy::MIN_COMMAND;
 
         let initial_commands = [0.0,0.3,0.7,1.0];
-        let max_iterations = 200;   // This should NOT be so slow... Boo.
+        let max_iterations = 10;
         for initial_command in initial_commands {
             let mut policy = InteractiveFrameRatePolicy::new(target_update_period);
             policy.command = initial_command;

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -1,5 +1,3 @@
-use std::{f32::MIN_POSITIVE, os::raw};
-
 use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, LinearInterpolator};
 
 #[derive(Clone, Debug)]
@@ -152,29 +150,29 @@ impl InteractiveFrameRatePolicy {
     const MIN_PERIOD: f64 = 0.0;
 
     pub fn new(timing_params: InteractiveFrameRateTimingParams) -> InteractiveFrameRatePolicy {
-        const NOMINAL_COMMAND: f64 = 0.5 * (Self::MAX_COMMAND + Self::MIN_COMMAND);
+        let nominal_command: f64 = 0.5 * (Self::MAX_COMMAND + Self::MIN_COMMAND);
         let command_margin =
             timing_params.normalized_margin * (Self::MAX_COMMAND - Self::MIN_COMMAND);
         let period_margin = timing_params.normalized_margin
             * (timing_params.max_expected_period - Self::MIN_PERIOD);
         let keyframes: Vec<InterpolationKeyframe<f64, f64>> = vec![
             InterpolationKeyframe {
-                input: Self::MIN_PERIOD - period_margin,
-                output: Self::MIN_COMMAND - command_margin,
+                query: Self::MIN_PERIOD - period_margin,
+                value: Self::MIN_COMMAND - command_margin,
             },
             InterpolationKeyframe {
-                input: timing_params.target_update_period,
-                output: NOMINAL_COMMAND,
+                query: timing_params.target_update_period,
+                value: nominal_command,
             },
             InterpolationKeyframe {
-                input: timing_params.max_expected_period + period_margin,
-                output: Self::MAX_COMMAND + command_margin,
+                query: timing_params.max_expected_period + period_margin,
+                value: Self::MAX_COMMAND + command_margin,
             },
         ];
         InteractiveFrameRatePolicy {
             timing_params,
             policy: KeyframeInterpolator::new(keyframes, LinearInterpolator),
-            command: NOMINAL_COMMAND,
+            command: nominal_command,
         }
     }
 
@@ -198,5 +196,20 @@ impl InteractiveFrameRatePolicy {
         self.command = raw_command.clamp(Self::MIN_COMMAND, Self::MAX_COMMAND);
 
         self.command
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AdaptiveOptimizationRegulator {
+
+}
+
+impl AdaptiveOptimizationRegulator {
+    pub fn new(_time: f64) -> Self {
+        Self {}
+    }
+
+    pub fn update(&mut self, _period: f64, _user_interaction: bool) -> Option<f64> {
+None
     }
 }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -169,7 +169,7 @@ impl InteractiveFrameRatePolicy {
     // command on construction. IN both cases, we can probably construct a new object
     // on entry and then destroy it when we switch FSM state. This keeps the logic simpler.
 
-    pub fn evaluate_policy(&mut self,  previous_command: f64,measured_period: f64) -> f64 {
+    pub fn evaluate(&mut self,  previous_command: f64,measured_period: f64) -> f64 {
         // (0) Ensure that the measurement is within the expected range, which in turn
         //     will ensure that the model remains invertable (and we can update the policy).
         let clamped_measured_period = measured_period.max(Self::MIN_PERIOD);
@@ -252,7 +252,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
             InteractiveFrameRatePolicy::new(target_update_period, max_command_delta);
         let initial_command = 0.5; // Set an initial non-trivial command for this test.
         for _ in 0..10 {
-            let command = policy.evaluate_policy( initial_command, nominal_period);
+            let command = policy.evaluate( initial_command, nominal_period);
             assert_relative_eq!(command, initial_command, epsilon = 1e-6);
         }
     }
@@ -267,7 +267,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
         let mut policy = InteractiveFrameRatePolicy::new(target_update_period, max_command_delta);
         let mut prev_command = 0.0;
         for _ in 0..25 {
-            let next_command = policy.evaluate_policy( prev_command, render_period_too_slow);
+            let next_command = policy.evaluate( prev_command, render_period_too_slow);
             assert_ge!(next_command, prev_command);
             assert_le!(next_command, InteractiveFrameRatePolicy::MAX_COMMAND);
             prev_command = next_command;
@@ -289,7 +289,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
         let mut policy = InteractiveFrameRatePolicy::new(target_update_period, max_command_delta);
         let mut prev_command = 0.05;
         for _ in 0..25 {
-            let next_command = policy.evaluate_policy( prev_command, render_period_too_fast);
+            let next_command = policy.evaluate( prev_command, render_period_too_fast);
             assert_le!(next_command, prev_command);
             assert_ge!(next_command, InteractiveFrameRatePolicy::MIN_COMMAND);
             prev_command = next_command;
@@ -314,7 +314,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
         for _ in 0..500 {
             let index = rng.gen_range(0..periods_to_test.len());
             let period = target_update_period * periods_to_test[index];
-            command = policy.evaluate_policy( command, period);
+            command = policy.evaluate( command, period);
             assert_le!(command, InteractiveFrameRatePolicy::MAX_COMMAND);
             assert_ge!(command, InteractiveFrameRatePolicy::MIN_COMMAND);
         }
@@ -418,7 +418,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
         let mut prev_command = initial_command;
         for _ in 0..num_iterations {
             let prev_period = render_proxy.evaluate(prev_command);
-            let next_command = policy.evaluate_policy( prev_command, prev_period);
+            let next_command = policy.evaluate( prev_command, prev_period);
             let next_period = render_proxy.evaluate(next_command);
 
             // println!(

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -242,70 +242,6 @@ mod tests {
     use rand::Rng;
     use rand::SeedableRng;
 
-    /// Model that maps from a command to a period, enulating the I/O behavior of the full
-    /// render pipeline. The "fast" variant will emulate a system that always renders faster
-    /// than the target period, regardless of the command. It does however satisfy the requirement
-    /// that a higher command will always yield a shorter period.
-    fn build_fast_render_proxy_model(
-        target_period: f64,
-    ) -> KeyframeInterpolator<f64, f64, LinearInterpolator> {
-        let keyframes: Vec<InterpolationKeyframe<f64, f64>> = vec![
-            InterpolationKeyframe {
-                query: 0.0,
-                value: 0.95 * target_period,
-            },
-            InterpolationKeyframe {
-                query: 0.1,
-                value: 0.7 * target_period,
-            },
-            InterpolationKeyframe {
-                query: 0.4,
-                value: 0.4 * target_period,
-            },
-            InterpolationKeyframe {
-                query: 1.0,
-                value: 0.05 * target_period,
-            },
-        ];
-        KeyframeInterpolator::new(keyframes, LinearInterpolator)
-    }
-
-    /// Simulates a combined "controller and render pipeline proxy", allowing us to
-    /// test the closed-loop performance in various scenarios. It monitors convergence
-    /// of the system toward the expected steadty state behavior, and returns true if the system
-    /// converged within the specified number of iterations.
-    fn simulate_controller(
-        policy: &mut InteractiveFrameRatePolicy,
-        render_proxy: &KeyframeInterpolator<f64, f64, LinearInterpolator>,
-        num_iterations: usize,
-        steady_state_period: f64,
-        steady_state_command: f64,
-        convergence_tol: f64,
-    ) -> bool {
-        for _ in 0..num_iterations {
-            let prev_command = policy.command;
-            let prev_period = render_proxy.evaluate(prev_command);
-            let next_command = policy.evaluate_policy(prev_period);
-            let next_period = render_proxy.evaluate(next_command);
-
-            let prev_cmd_err = (prev_command - steady_state_command).abs();
-            let next_cmd_err = (next_command - steady_state_command).abs();
-            assert_le!(next_cmd_err, prev_cmd_err);
-
-            let prev_period_err = (prev_period - steady_state_period).abs();
-            let next_period_err = (next_period - steady_state_period).abs();
-            assert_le!(next_period_err, prev_period_err);
-
-            // If the command and period errors are both small enough, we can consider the system
-            // to have converged to a steady state.
-            if next_cmd_err < convergence_tol && next_period_err < convergence_tol {
-                return true;
-            }
-        }
-        // If we reach here, the system did not converge within the specified iterations.
-        false
-    }
-
     #[test]
     fn test_interactive_frame_rate_policy_steady_state_convergence_nominal() {
         // Given the nominal period, the command should not change.
@@ -390,12 +326,89 @@ mod tests {
         }
     }
 
+
+
+    /// Model that maps from a command to a period, enulating the I/O behavior of the full
+    /// render pipeline. The "fast" variant will emulate a system that always renders faster
+    /// than the target period, regardless of the command. It does however satisfy the requirement
+    /// that a higher command will always yield a shorter period.
+    fn build_fast_render_proxy_model(
+        target_period: f64,
+    ) -> KeyframeInterpolator<f64, f64, LinearInterpolator> {
+        let keyframes: Vec<InterpolationKeyframe<f64, f64>> = vec![
+            InterpolationKeyframe {
+                query: 0.0,
+                value: 0.95 * target_period,
+            },
+            InterpolationKeyframe {
+                query: 0.1,
+                value: 0.7 * target_period,
+            },
+            InterpolationKeyframe {
+                query: 0.4,
+                value: 0.4 * target_period,
+            },
+            InterpolationKeyframe {
+                query: 1.0,
+                value: 0.05 * target_period,
+            },
+        ];
+        KeyframeInterpolator::new(keyframes, LinearInterpolator)
+    }
+
+    /// Simulates a combined "controller and render pipeline proxy", allowing us to
+    /// test the closed-loop performance in various scenarios. It monitors convergence
+    /// of the system toward the expected steadty state behavior, and returns true if the system
+    /// converged within the specified number of iterations.
+    fn simulate_controller(
+        policy: &mut InteractiveFrameRatePolicy,
+        render_proxy: &KeyframeInterpolator<f64, f64, LinearInterpolator>,
+        num_iterations: usize,
+        steady_state_period: f64,
+        steady_state_command: f64,
+        convergence_tol: f64,
+    ) -> bool {
+        for _ in 0..num_iterations {
+            let prev_command = policy.command;
+            let prev_period = render_proxy.evaluate(prev_command);
+            let next_command = policy.evaluate_policy(prev_period);
+            let next_period = render_proxy.evaluate(next_command);
+
+            println!(
+                "Prev Command: {:.6}, Prev Period: {:.6}, Next Command: {:.6}, Next Period: {:.6}",
+                prev_command, prev_period, next_command, next_period
+            );  // HACK!!!
+
+            let prev_cmd_err = (prev_command - steady_state_command).abs();
+            let next_cmd_err = (next_command - steady_state_command).abs();
+            assert_le!(next_cmd_err, prev_cmd_err);
+
+            let prev_period_err = (prev_period - steady_state_period).abs();
+            let next_period_err = (next_period - steady_state_period).abs();
+            assert_le!(next_period_err, prev_period_err);
+
+            println!(
+                "Prev Command Error: {:.6}, Next Command Error: {:.6}, Prev Period Error: {:.6}, Next Period Error: {:.6}",
+                prev_cmd_err, next_cmd_err, prev_period_err, next_period_err
+            );  // HACK!!
+
+            // If the command and period errors are both small enough, we can consider the system
+            // to have converged to a steady state.
+            if next_cmd_err < convergence_tol && next_period_err < convergence_tol {
+                return true;
+            }
+        }
+        // If we reach here, the system did not converge within the specified iterations.
+        false
+    }
+
+
     #[test]
     fn test_interactive_frame_rate_policy_closed_loop_fast_render() {
         let timing_params = InteractiveFrameRateTimingParams::new();
         let render_proxy = build_fast_render_proxy_model(timing_params.target_update_period);
-        let steady_state_period = *render_proxy.values().last().unwrap();
-        let steady_state_command = InteractiveFrameRatePolicy::MAX_COMMAND;
+        let steady_state_period = *render_proxy.values().first().unwrap();
+        let steady_state_command = InteractiveFrameRatePolicy::MIN_COMMAND;
         let mut policy = InteractiveFrameRatePolicy::new(timing_params);
         let converged = simulate_controller(
             &mut policy,
@@ -406,8 +419,7 @@ mod tests {
             1e-6,
         );
         assert!(
-            converged,
-            "The controller did not converge to the expected steady state behavior."
+            converged
         );
     }
 }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -248,6 +248,13 @@ impl InteractiveFrameRatePolicy {
 /// It is initially fit to two data points, sampled at the bounds of the command range,
 /// and is then updated on each iteration by scaling the amplitude A to
 /// match the most recent measurement.
+///
+/// EDIT:  This is way fancier than it needs to be.  I ran the data, and I think we're better
+/// just hard-coding B to 1.0, and then just scaling A to match the most recent measurement.
+/// This model is simpler, but also more robust, because it does not require us to "latch and
+/// remeber" the first two samples, which quickly beomce irrelevant as the system converges.
+/// We're modifying the model live, so we jsut need it to give the correct overall trends, not the
+/// exact values.
 struct ExponentialRenderPeriodModel {
     a: f64,
     b: f64,

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -409,17 +409,22 @@ mod tests {
         let render_proxy = build_fast_render_proxy_model(timing_params.target_update_period);
         let steady_state_period = *render_proxy.values().first().unwrap();
         let steady_state_command = InteractiveFrameRatePolicy::MIN_COMMAND;
-        let mut policy = InteractiveFrameRatePolicy::new(timing_params);
-        let converged = simulate_controller(
-            &mut policy,
-            &render_proxy,
-            50,
-            steady_state_period,
-            steady_state_command,
-            1e-6,
-        );
-        assert!(
-            converged
-        );
+
+        let initial_commands = [0.0,0.3,0.7,1.0];
+        let max_iterations = 200;   // This should NOT be so slow... Boo.
+        for initial_command in initial_commands {
+            let mut policy = InteractiveFrameRatePolicy::new(timing_params.clone());
+            policy.command = initial_command;
+            let converged = simulate_controller(
+                &mut policy,
+                &render_proxy,max_iterations,
+                steady_state_period,
+                steady_state_command,
+                1e-2,
+            );
+            assert!(
+                converged, "Failed to converge with initial command: {:.6}", initial_command
+            );
+        }
     }
 }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -161,9 +161,9 @@ pub struct InteractiveFrameRatePolicy {
 }
 
 impl InteractiveFrameRatePolicy {
-    const MAX_COMMAND: f64 = 1.0;
-    const MIN_COMMAND: f64 = 0.0;
-    const MIN_PERIOD: f64 = 0.0;
+   pub const MAX_COMMAND: f64 = 1.0;
+  pub  const MIN_COMMAND: f64 = 0.0;
+  pub  const MIN_PERIOD: f64 = 0.0;
 
     pub fn new(timing_params: InteractiveFrameRateTimingParams) -> InteractiveFrameRatePolicy {
         let nominal_command: f64 = 0.5 * (Self::MAX_COMMAND + Self::MIN_COMMAND);
@@ -228,3 +228,55 @@ impl AdaptiveOptimizationRegulator {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use more_asserts::{assert_gt, assert_lt};
+
+    #[test]
+    fn test_interactive_frame_rate_policy_steady_state_convergence_nominal() {
+        // Given the nominal period, the command should not change.
+        let timing_params = InteractiveFrameRateTimingParams::new();
+        let nominal_period = timing_params.target_update_period;
+        let mut policy = InteractiveFrameRatePolicy::new(timing_params);
+        let initial_command = policy.command;
+        for _ in 0..10 {
+            let command = policy.evaluate_policy(nominal_period);
+            assert_relative_eq!(command, initial_command, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_interactive_frame_rate_policy_steady_state_convergence_too_slow() {
+        let timing_params = InteractiveFrameRateTimingParams::new();
+        let render_period_too_slow = 4.0 * timing_params.target_update_period;
+
+        // Given a slow period, the command should increase, eventually saturating at 1.0.
+        let mut policy = InteractiveFrameRatePolicy::new(timing_params);
+        for _ in 0..10 {
+            let prev_command = policy.command;
+            let next_command = policy.evaluate_policy(render_period_too_slow);
+            assert_gt!(next_command, prev_command);
+            assert_lt!(next_command, InteractiveFrameRatePolicy::MAX_COMMAND);
+        }
+        assert_relative_eq!(policy.command, InteractiveFrameRatePolicy::MAX_COMMAND, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn test_interactive_frame_rate_policy_steady_state_convergence_too_fast() {
+        let timing_params = InteractiveFrameRateTimingParams::new();
+        let render_period_too_slow = 4.0 * timing_params.target_update_period;
+
+        // Given a slow period, the command should increase, eventually saturating at 1.0.
+        let mut policy = InteractiveFrameRatePolicy::new(timing_params);
+        for _ in 0..10 {
+            let prev_command = policy.command;
+            let next_command = policy.evaluate_policy(render_period_too_slow);
+            assert_lt!(next_command, prev_command);
+            assert_gt!(next_command, InteractiveFrameRatePolicy::MIN_COMMAND);
+        }
+        assert_relative_eq!(policy.command, InteractiveFrameRatePolicy::MIN_COMMAND, epsilon = 1e-3);
+    }
+
+}

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -254,8 +254,8 @@ impl AdaptiveOptimizationRegulator {
 
     pub fn render_required(&mut self, is_interactive: bool) -> Option<f64> {
         self.render_policy_fsm.render_required(
-            self.render_period,
             self.render_command,
+            self.render_period,
             is_interactive,
         )
     }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -241,60 +241,60 @@ mod tests {
 
     }
 
-    // #[test]
-    // fn test_interactive_frame_rate_policy_steady_state_convergence_nominal() {
-    //     // Given the nominal period, the command should not change.
-    //     let target_update_period = 0.025;
-    //     let nominal_period = target_update_period;
-    //     let mut policy: InteractiveFrameRatePolicy = InteractiveFrameRatePolicy::new(target_update_period);
-    //     policy.command = 0.5; // Set an initial non-trivial command for this test.
-    //     let initial_command = policy.command;
-    //     for _ in 0..10 {
-    //         let command = policy.evaluate_policy(nominal_period);
-    //         assert_relative_eq!(command, initial_command, epsilon = 1e-6);
-    //     }
-    // }
+    #[test]
+    fn test_interactive_frame_rate_policy_steady_state_convergence_nominal() {
+        // Given the nominal period, the command should not change.
+        let target_update_period = 0.025;
+        let nominal_period = target_update_period;
+        let mut policy: InteractiveFrameRatePolicy = InteractiveFrameRatePolicy::new(target_update_period);
+        policy.command = 0.5; // Set an initial non-trivial command for this test.
+        let initial_command = policy.command;
+        for _ in 0..10 {
+            let command = policy.evaluate_policy(nominal_period);
+            assert_relative_eq!(command, initial_command, epsilon = 1e-6);
+        }
+    }
 
-    // #[test]
-    // fn test_interactive_frame_rate_policy_steady_state_convergence_too_slow() {
-    //     let target_update_period = 0.025;
-    //     let render_period_too_slow = 4.0 * target_update_period;
+    #[test]
+    fn test_interactive_frame_rate_policy_steady_state_convergence_too_slow() {
+        let target_update_period = 0.025;
+        let render_period_too_slow = 4.0 * target_update_period;
 
-    //     // Given a slow period, the command should increase, eventually saturating at 1.0.
-    //     let mut policy = InteractiveFrameRatePolicy::new(target_update_period);
-    //     for _ in 0..25 {
-    //         let prev_command = policy.command;
-    //         let next_command = policy.evaluate_policy(render_period_too_slow);
-    //         assert_ge!(next_command, prev_command);
-    //         assert_le!(next_command, InteractiveFrameRatePolicy::MAX_COMMAND);
-    //     }
-    //     assert_relative_eq!(
-    //         policy.command,
-    //         InteractiveFrameRatePolicy::MAX_COMMAND,
-    //         epsilon = 1e-3
-    //     );
-    // }
+        // Given a slow period, the command should increase, eventually saturating at 1.0.
+        let mut policy = InteractiveFrameRatePolicy::new(target_update_period);
+        for _ in 0..25 {
+            let prev_command = policy.command;
+            let next_command = policy.evaluate_policy(render_period_too_slow);
+            assert_ge!(next_command, prev_command);
+            assert_le!(next_command, InteractiveFrameRatePolicy::MAX_COMMAND);
+        }
+        assert_relative_eq!(
+            policy.command,
+            InteractiveFrameRatePolicy::MAX_COMMAND,
+            epsilon = 1e-3
+        );
+    }
 
-    // #[test]
-    // fn test_interactive_frame_rate_policy_steady_state_convergence_too_fast() {
-    //     let target_update_period = 0.025;
-    //     let render_period_too_fast = 0.2 * target_update_period;
+    #[test]
+    fn test_interactive_frame_rate_policy_steady_state_convergence_too_fast() {
+        let target_update_period = 0.025;
+        let render_period_too_fast = 0.2 * target_update_period;
 
-    //     // Given a slow period, the command should increase, eventually saturating at 1.0.
-    //     let mut policy = InteractiveFrameRatePolicy::new(target_update_period);
-    //     policy.command = 0.05; // Set an initial non-trivial command to check convergence.
-    //     for _ in 0..25 {
-    //         let prev_command = policy.command;
-    //         let next_command = policy.evaluate_policy(render_period_too_fast);
-    //         assert_le!(next_command, prev_command);
-    //         assert_ge!(next_command, InteractiveFrameRatePolicy::MIN_COMMAND);
-    //     }
-    //     assert_relative_eq!(
-    //         policy.command,
-    //         InteractiveFrameRatePolicy::MIN_COMMAND,
-    //         epsilon = 1e-3
-    //     );
-    // }
+        // Given a slow period, the command should increase, eventually saturating at 1.0.
+        let mut policy = InteractiveFrameRatePolicy::new(target_update_period);
+        policy.command = 0.05; // Set an initial non-trivial command to check convergence.
+        for _ in 0..25 {
+            let prev_command = policy.command;
+            let next_command = policy.evaluate_policy(render_period_too_fast);
+            assert_le!(next_command, prev_command);
+            assert_ge!(next_command, InteractiveFrameRatePolicy::MIN_COMMAND);
+        }
+        assert_relative_eq!(
+            policy.command,
+            InteractiveFrameRatePolicy::MIN_COMMAND,
+            epsilon = 1e-3
+        );
+    }
 
     #[test]
     fn test_interactive_frame_rate_policy_bad_input_fuzz_test() {

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -127,9 +127,25 @@ pub struct InteractiveFrameRateTimingParams {
     normalized_margin: f64,
 }
 
+impl InteractiveFrameRateTimingParams {
+    pub fn new() -> InteractiveFrameRateTimingParams {
+        Self {
+            target_update_period: 0.040, // 25 frames per second
+            max_expected_period: 0.5,
+            normalized_margin: 0.05,
+        }
+    }
+}
+
+impl Default for InteractiveFrameRateTimingParams {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct InteractiveFrameRatePolicy {
-    // User-specified parameters for the timing policy -- do not change after construction.
+    // User-specified parameters for the timing policy, which do not change after construction.
     timing_params: InteractiveFrameRateTimingParams,
 
     // The policy is implemented by linear interpolation between keyframes,
@@ -200,9 +216,7 @@ impl InteractiveFrameRatePolicy {
 }
 
 #[derive(Clone, Debug)]
-pub struct AdaptiveOptimizationRegulator {
-
-}
+pub struct AdaptiveOptimizationRegulator {}
 
 impl AdaptiveOptimizationRegulator {
     pub fn new(_time: f64) -> Self {
@@ -210,6 +224,7 @@ impl AdaptiveOptimizationRegulator {
     }
 
     pub fn update(&mut self, _period: f64, _user_interaction: bool) -> Option<f64> {
-None
+        None
     }
 }
+

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -180,6 +180,23 @@ impl InteractiveFrameRatePolicy {
                 query: timing_params.target_update_period,
                 value: nominal_command,
             },
+
+            // MPK:  problem here. This data point is sometimes *really* bad.
+            // The system still converges, but it takes a long time.
+            // Probably a good idea here is to add two probe values at the edges.
+            // First evaluation runs at command = 1.0.
+            // Second evaluation runs at command = 0.0.
+            // Then, set the value of the middle keyframe as linear interpolation
+            // between the two probes. THEN start the regular algorithm.
+            // Also, rather than always updating this middle keyframe, we can
+            // update the closest of the three keyframes to the measured period...
+            // We we need to be careful to ensure that the model remains invertable.
+            // ... this is a modification on linear K-nearest-neighbor interpolation...
+            // But it should fix the convergence issues.
+            //
+            // ... could go even simpler, with a two-point model, which would make the check
+            // for which point and also for monotonicity much easier. But probably nice to have
+            // the three-point model for faster convergence.
             InterpolationKeyframe {
                 query: timing_params.max_expected_period + period_margin,
                 value: Self::MIN_COMMAND - command_margin,

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -212,51 +212,16 @@ impl InteractiveFrameRatePolicy {
 
 ///////////////////////////////////////////////////////////////////////////
 
-
 #[derive(Clone, Debug)]
-pub struct AdaptiveOptimizationRegulator {
-    // Time recorded during update or construction; stateful; used to compute period.
-    time: f64,
-
-    // TODO
-    command: Option<f64>,
-
-    // Policy that is evaluated to adjust frame rate while the user is actively interacting.
-    interactive_frame_rate_policy: InteractiveFrameRatePolicy,
-
-}
+pub struct AdaptiveOptimizationRegulator {}
 
 impl AdaptiveOptimizationRegulator {
-    pub fn new(time: f64,  target_update_period: f64) -> Self {
-        Self {
-            time,
-            interactive_frame_rate_policy: InteractiveFrameRatePolicy::new(target_update_period),
-        }
+    pub fn new(_time: f64) -> Self {
+        Self {}
     }
 
-    pub fn update(&mut self, time: f64, user_interaction: bool) -> Option<f64> {
-        let measured_period = time - self.time;
-        self.time = time;
-        if user_interaction{
-           self.command =  Some(self.interactive_frame_rate_policy.evaluate_policy(measured_period));
-        } else {
-            // if let Some(prev_cmd) = self.command {
-            //     if
-            //     let next_command = prev_cmd - 0.1;
-
-            // }
-
-            // Ok - this is slightly more subtle than I had thought. We should just make a simple 3-state FSM to correctly
-            // handle these three modes:
-            // -- active update
-            // -- passive update
-            // -- idle
-
-
-None()
-
-        }
-        self.command
+    pub fn update(&mut self, _period: f64, _user_interaction: bool) -> Option<f64> {
+        None
     }
 }
 

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -262,6 +262,7 @@ impl AdaptiveOptimizationRegulator {
 
     // Called by the render pipeline whenever a new render begins.
     pub fn begin_rendering(&mut self, time: f64, command: f64) {
+        println!("Begin rendering...   time: {}", time);
         self.render_start_time = Some(time);
         self.render_period = None;
         self.render_command = Some(command);
@@ -270,11 +271,11 @@ impl AdaptiveOptimizationRegulator {
     // Called by the render pipeline whenever the render is completed
     pub fn finish_rendering(&mut self, time: f64) {
         if let Some(start_time) = self.render_start_time {
+            println!("Finish rendering...   time: {}", time);
             self.render_period = Some(time - start_time);
             self.render_start_time = None;
         } else {
-            println!("ERROR: 'finish_rendering' called before 'begin_rendering'!");
-            panic!();
+            println!("Finish rendering called again because redrawing takes a looong time...   time: {}", time);
         }
     }
 }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -1,5 +1,7 @@
 use more_asserts::{assert_ge, assert_gt};
 
+use crate::core::render_quality_fsm::RenderQualityPolicy;
+
 #[derive(Clone, Debug)]
 pub enum Target {
     Position { pos_ref: f64, max_vel: f64 },
@@ -150,18 +152,15 @@ pub struct InteractiveFrameRatePolicy {
 }
 
 impl InteractiveFrameRatePolicy {
-    // TOODO:  move to render policy trait
-    pub const MAX_COMMAND: f64 = 1.0;
-    pub const MIN_COMMAND: f64 = 0.0;
-    pub const MIN_PERIOD: f64 = 0.0;
-
     pub fn new(target_update_period: f64, max_command_delta: f64) -> InteractiveFrameRatePolicy {
         InteractiveFrameRatePolicy {
             target_update_period,
             max_command_delta,
         }
     }
+}
 
+impl RenderQualityPolicy for InteractiveFrameRatePolicy {
     // WE don't always know the update period here. On this first tick, we have not yet i
     // issued a command, so the period is meaningless -- in that case we should open loop
     // send out the "default command" that we are constructed with.
@@ -170,7 +169,7 @@ impl InteractiveFrameRatePolicy {
     // command on construction. IN both cases, we can probably construct a new object
     // on entry and then destroy it when we switch FSM state. This keeps the logic simpler.
 
-    pub fn evaluate(&mut self, previous_command: f64, measured_period: f64) -> f64 {
+    fn evaluate(&mut self, previous_command: f64, measured_period: f64) -> f64 {
         // (0) Ensure that the measurement is within the expected range, which in turn
         //     will ensure that the model remains invertable (and we can update the policy).
         let clamped_measured_period = measured_period.max(Self::MIN_PERIOD);

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -169,7 +169,7 @@ impl InteractiveFrameRatePolicy {
     // command on construction. IN both cases, we can probably construct a new object
     // on entry and then destroy it when we switch FSM state. This keeps the logic simpler.
 
-    pub fn evaluate_policy(&mut self, measured_period: f64, previous_command: f64) -> f64 {
+    pub fn evaluate_policy(&mut self,  previous_command: f64,measured_period: f64) -> f64 {
         // (0) Ensure that the measurement is within the expected range, which in turn
         //     will ensure that the model remains invertable (and we can update the policy).
         let clamped_measured_period = measured_period.max(Self::MIN_PERIOD);
@@ -252,7 +252,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
             InteractiveFrameRatePolicy::new(target_update_period, max_command_delta);
         let initial_command = 0.5; // Set an initial non-trivial command for this test.
         for _ in 0..10 {
-            let command = policy.evaluate_policy(nominal_period, initial_command);
+            let command = policy.evaluate_policy( initial_command, nominal_period);
             assert_relative_eq!(command, initial_command, epsilon = 1e-6);
         }
     }
@@ -267,7 +267,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
         let mut policy = InteractiveFrameRatePolicy::new(target_update_period, max_command_delta);
         let mut prev_command = 0.0;
         for _ in 0..25 {
-            let next_command = policy.evaluate_policy(render_period_too_slow, prev_command);
+            let next_command = policy.evaluate_policy( prev_command, render_period_too_slow);
             assert_ge!(next_command, prev_command);
             assert_le!(next_command, InteractiveFrameRatePolicy::MAX_COMMAND);
             prev_command = next_command;
@@ -289,7 +289,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
         let mut policy = InteractiveFrameRatePolicy::new(target_update_period, max_command_delta);
         let mut prev_command = 0.05;
         for _ in 0..25 {
-            let next_command = policy.evaluate_policy(render_period_too_fast, prev_command);
+            let next_command = policy.evaluate_policy( prev_command, render_period_too_fast);
             assert_le!(next_command, prev_command);
             assert_ge!(next_command, InteractiveFrameRatePolicy::MIN_COMMAND);
             prev_command = next_command;
@@ -314,7 +314,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
         for _ in 0..500 {
             let index = rng.gen_range(0..periods_to_test.len());
             let period = target_update_period * periods_to_test[index];
-            command = policy.evaluate_policy(period, command);
+            command = policy.evaluate_policy( command, period);
             assert_le!(command, InteractiveFrameRatePolicy::MAX_COMMAND);
             assert_ge!(command, InteractiveFrameRatePolicy::MIN_COMMAND);
         }
@@ -418,7 +418,7 @@ use crate::core::interpolation::{InterpolationKeyframe, KeyframeInterpolator, Li
         let mut prev_command = initial_command;
         for _ in 0..num_iterations {
             let prev_period = render_proxy.evaluate(prev_command);
-            let next_command = policy.evaluate_policy(prev_period, prev_command);
+            let next_command = policy.evaluate_policy( prev_command, prev_period);
             let next_period = render_proxy.evaluate(next_command);
 
             // println!(

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -58,6 +58,14 @@ where
         }
     }
 
+    pub fn queries(&self) -> &[T] {
+        &self.queries
+    }
+
+    pub fn values(&self) -> &[V] {
+        &self.values
+    }
+
     pub fn set_keyframe_query(&mut self, index: usize, query: T) {
         assert!(
             index < self.queries.len(),
@@ -335,7 +343,7 @@ mod tests {
         assert_relative_eq!(interp.evaluate(-0.0), 20.0, epsilon = 1e-6);
         assert_relative_eq!(interp.evaluate(3.0), 128.0, epsilon = 1e-6); // interpolate
         assert_relative_eq!(interp.evaluate(5.0), 200.0, epsilon = 1e-6);
-        assert_relative_eq!(interp.evaluate(7.0), 120.0, epsilon = 1e-6); // interpolate
+        assert_relative_eq!(interp.evaluate(7.0), 120.0, epsilon = 1e-6); // interpolateg
         assert_relative_eq!(interp.evaluate(10.0), 0.0, epsilon = 1e-6);
         assert_relative_eq!(interp.evaluate(18.0), 0.0, epsilon = 1e-6); // extrapolate (clamped)
     }

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -58,7 +58,6 @@ where
         }
     }
 
-    #[cfg(test)]
     pub fn set_keyframe_query(&mut self, index: usize, query: T) {
         assert!(
             index < self.queries.len(),
@@ -79,7 +78,6 @@ where
         self.queries[index] = query;
     }
 
-    #[cfg(test)]
     pub fn set_keyframe_value(&mut self, index: usize, value: V) {
         assert!(
             index < self.queries.len(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,3 +11,4 @@ pub mod ode_solvers;
 pub mod render_window;
 pub mod stopwatch;
 pub mod view_control;
+pub mod render_quality_fsm;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,7 +8,7 @@ pub mod image_utils;
 pub mod interpolation;
 pub mod lookup_table;
 pub mod ode_solvers;
+pub mod render_quality_fsm;
 pub mod render_window;
 pub mod stopwatch;
 pub mod view_control;
-pub mod render_quality_fsm;

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -7,20 +7,18 @@
 //! high quality, we should shut down the render pipeline to conserve
 //! resources (no need to spin at max CPU while idle...).
 
-
 // (1) updat the Interactive state to go back to the optional f64 for time. I realized that we always need the previous command.
 // (2) pass the previous command to the user policy (making it stateless)
 // (3) use the same generic interface for the "idle policy" (allow the user to pass in an idle and a interactive policy).
 // (4) make max delta an implementation detail of the user policies
 // (5) use the same interface and design pattern for both interactive and background modes.
 
-
 pub trait RenderQualityPolicy {
     /// @param previous_command: last render command that was completed
     /// @param measured_period: how long did that render command take to complete?
     /// @return: render quality command (0 = maximum quality; 1 = maximum speed)
-    ///     or None (indicating that the render pipeline should not run).
-    fn evaluate(&mut self,  previous_command: f64, measured_period: f64) -> Option<f64>;
+    ///     out of bound commands will be clamped to [0,1]
+    fn evaluate(&mut self, previous_command: f64, measured_period: f64) -> f64;
 }
 
 use more_asserts::{assert_ge, assert_gt, assert_le};
@@ -32,28 +30,27 @@ pub enum Mode {
     Idle,
 }
 
-
 #[derive(Debug)]
-pub struct FiniteStateMachine<F,G>
+pub struct FiniteStateMachine<F, G>
 where
     F: RenderQualityPolicy,
     G: RenderQualityPolicy,
 {
-    mode: Mode,  // which mode are we in right now?
-    begin_rendering_command: f64,  // what is the command to send when we first start rendering?
+    mode: Mode,                   // which mode are we in right now?
+    begin_rendering_command: f64, // what is the command to send when we first start rendering?
     prev_render_command: f64,
-    prev_render_time: f64,
+    prev_update_time: f64,
     interactive_policy: F,
     background_policy: G,
 }
 
-impl<F,G> FiniteStateMachine<F, G>
+impl<F, G> FiniteStateMachine<F, G>
 where
     F: RenderQualityPolicy,
     G: RenderQualityPolicy,
 {
     /// Create a new FSM for regularing the render quality.
-    pub fn new(initial_command: f64,interactive_policy: F, background_policy: G) -> Self {
+    pub fn new(initial_command: f64, interactive_policy: F, background_policy: G) -> Self {
         assert_ge!(initial_command, 0.0);
         assert_le!(initial_command, 1.0);
         let initial_command = initial_command.clamp(0.0, 1.0);
@@ -61,203 +58,59 @@ where
             mode: Mode::BeginRendering,
             begin_rendering_command: initial_command,
             prev_render_command: initial_command,
-            prev_render_time: 0.0,
+            prev_update_time: 0.0,
             interactive_policy,
             background_policy,
         }
     }
 
-    fn transition_logic(&mut self, is_interactive: bool) {
-        match (self.mode, is_interactive) {
-            (Mode::BeginRendering, true) => {
-                self.mode = Mode::Interactive;
-            }
-                     (Mode::BeginRendering, false) => {
-                self.mode = Mode::Background;
-                // TODO?
-            }
-            (Mode::Background, true) => {
-                self.mode = Mode::Interactive;
-            }
-            (Mode::Interactive, false) => {
-                self.interactive.reset(self.prev_command);
-                self.mode = Mode::Background;
-            }
-            (Mode::Idle, true) => {
-                self.mode = Mode::Interactive;
-            }
-            // Otherwise, remain in current mode
-            _ => { /* no-op */ }
-        }
-    }
-
-    /// Update the render FSM and return the render command, if any is needed.
-    pub fn update(&mut self, time: f64, is_interactive: bool) -> Option<f64> {
-        self.transition_logic(is_interactive);
-
-        // --- Actions (mode-specific behavior) ---
-        match self.mode {
-            Mode::Interactive => {
-                self.prev_command = self.interactive.update(time, self.max_command_delta);
-                Some(self.prev_command)
-            }
-            Mode::Background => self.background_update(),
-            Mode::Idle => None,
-        }
-    }
-
-    /// Implementation of the update while in background mode. Gradually reduce the
-    /// command toward zero, and then switch to Idle mode once we get there.
-    fn background_update(&mut self) -> Option<f64> {
-        let raw_command = self.prev_command - self.max_command_delta;
-
-        self.prev_command = if raw_command > 0.0 {
-            raw_command
+    pub fn update_begin_rendering(&mut self, is_interactive: bool) -> Option<f64> {
+        if is_interactive {
+            self.mode = Mode::Interactive;
         } else {
+            self.mode = Mode::Background;
+        }
+        self.prev_render_command = self.begin_rendering_command;
+        Some(self.prev_render_command)
+    }
+
+    pub fn update_interactive(&mut self, period: f64, is_interactive: bool) -> Option<f64> {
+        if !is_interactive {
+            self.mode = Mode::Background;
+        }
+        self.prev_render_command = self
+            .interactive_policy
+            .evaluate(self.prev_render_command, period)
+            .clamp(0.0, 1.0);
+        Some(self.prev_render_command)
+    }
+    pub fn update_background(&mut self, period: f64, is_interactive: bool) -> Option<f64> {
+        if is_interactive {
+            self.mode = Mode::Interactive;
+        }
+        let raw_render_command = self
+            .background_policy
+            .evaluate(self.prev_render_command, period);
+        if raw_render_command <= 0.0 {
             self.mode = Mode::Idle;
-            0.0
-        };
-        Some(self.prev_command)
+        }
+        self.prev_render_command = raw_render_command.clamp(0.0, 1.0);
+        Some(self.prev_render_command)
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use approx::assert_relative_eq;
-    use more_asserts::{assert_ge, assert_le};
-
-    fn policy(period: f64, max_delta: f64) -> f64 {
-        // Simple policy that uses both inputs:
-        // base = 2 * period; nudge by 0.5 * max_delta to prove plumbing.
-        2.0 * period + 0.5 * max_delta
+    pub fn update_idle(&mut self, is_interactive: bool) -> Option<f64> {
+        if is_interactive {
+            self.mode = Mode::BeginRendering;
+        }
+        None
     }
 
-    #[test]
-    fn construction_defaults() {
-        let fsm = FiniteStateMachine::new(0.3, 0.1, policy);
-        assert_eq!(fsm.mode(), Mode::Background);
-        assert_relative_eq!(fsm.prev_command(), 0.3);
-        assert!(!fsm.interactive_data().is_time_cached());
-        assert_ge!(fsm.prev_command(), 0.0);
-    }
-
-    #[test]
-    fn first_interactive_tick_returns_initial_and_caches_time() {
-        let mut fsm = FiniteStateMachine::new(0.3, 0.1, policy);
-        let out = fsm.update(1.0, true); // interactive
-        assert_eq!(fsm.mode(), Mode::Interactive);
-        assert!(fsm.interactive_data().is_time_cached());
-        assert_relative_eq!(out.unwrap(), 0.3);
-        assert_relative_eq!(fsm.prev_command(), 0.3);
-    }
-
-    #[test]
-    fn interactive_period_computes_policy_command() {
-        let mut fsm = FiniteStateMachine::new(0.3, 0.1, policy);
-        let _ = fsm.update(1.0, true); // first interactive tick returns initial command
-        // Next tick: period=0.1 => cmd = 2*0.1 + 0.5*0.1 = 0.2 + 0.05 = 0.25
-        let out = fsm.update(1.1, true);
-        assert_eq!(fsm.mode(), Mode::Interactive);
-        assert_relative_eq!(out.unwrap(), 0.25);
-        assert_relative_eq!(fsm.prev_command(), 0.25);
-        assert_ge!(fsm.prev_command(), 0.0);
-        assert_le!(fsm.prev_command(), 1.0); // stays within [0,1]
-    }
-
-    #[test]
-    #[should_panic]
-    fn interactive_nonmonotonic_time_panics() {
-        let mut fsm = FiniteStateMachine::new(0.3, 0.2, policy);
-        let _ = fsm.update(2.0, true); // first interactive tick
-        // time went backwards -> period <= 0 triggers assert_gt! panic
-        let _ = fsm.update(1.9, true);
-    }
-
-    #[test]
-    #[should_panic]
-    fn interactive_zero_period_panics() {
-        let mut fsm = FiniteStateMachine::new(0.3, 0.2, policy);
-        let _ = fsm.update(2.0, true);
-        // Same timestamp => period == 0.0 -> panic
-        let _ = fsm.update(2.0, true);
-    }
-
-    #[test]
-    fn interactive_to_background_then_decay() {
-        let mut fsm = FiniteStateMachine::new(0.3, 0.1, policy);
-        let _ = fsm.update(1.0, true); // returns 0.3
-        // period=0.2 => cmd=2*0.2+0.05=0.45
-        let _ = fsm.update(1.2, true);
-        assert_relative_eq!(fsm.prev_command(), 0.45);
-
-        // Flag goes false -> transition to background and decay in same tick
-        let out = fsm.update(1.3, false);
-        assert_eq!(fsm.mode(), Mode::Background);
-        assert_relative_eq!(out.unwrap(), 0.35); // 0.45 - 0.1
-        assert_relative_eq!(fsm.prev_command(), 0.35);
-
-        // Decay again (still background)
-        let out2 = fsm.update(1.4, false);
-        assert_eq!(fsm.mode(), Mode::Background);
-        assert_relative_eq!(out2.unwrap(), 0.25);
-        assert_relative_eq!(fsm.prev_command(), 0.25);
-    }
-
-    #[test]
-    fn background_to_idle_on_zero_crossing() {
-        let mut fsm = FiniteStateMachine::new(0.15, 0.1, policy);
-        assert_eq!(fsm.mode(), Mode::Background);
-
-        // 0.15 -> 0.05
-        let out1 = fsm.update(10.0, false);
-        assert_eq!(fsm.mode(), Mode::Background);
-        assert_relative_eq!(out1.unwrap(), 0.05);
-
-        // 0.05 -> 0.00, transitions to Idle and returns a final 0.0 once
-        let out2 = fsm.update(11.0, false);
-        assert_eq!(fsm.mode(), Mode::Idle);
-        assert_relative_eq!(out2.unwrap(), 0.0);
-        assert_relative_eq!(fsm.prev_command(), 0.0);
-    }
-
-    #[test]
-    fn idle_returns_none_until_interactive() {
-        let mut fsm = FiniteStateMachine::new(0.05, 0.1, policy);
-        // Background -> immediate decay to 0 -> Idle
-        let _ = fsm.update(0.0, false); // 0.05 -> 0.0 & idle
-        assert_eq!(fsm.mode(), Mode::Idle);
-
-        // Idle returns None (no command)
-        let out_none = fsm.update(1.0, false);
-        assert!(out_none.is_none());
-        assert_relative_eq!(fsm.prev_command(), 0.0);
-
-        // Any-state -> Interactive when flag set
-        let out_interactive = fsm.update(2.0, true);
-        assert_eq!(fsm.mode(), Mode::Interactive);
-        // First interactive tick returns the initial command (0.05)
-        assert_relative_eq!(out_interactive.unwrap(), 0.05);
-        assert_relative_eq!(fsm.prev_command(), 0.05);
-    }
-
-    #[test]
-    fn reenter_interactive_returns_last_interactive_command() {
-        let mut fsm = FiniteStateMachine::new(0.3, 0.1, policy);
-        // First interactive tick -> 0.3
-        let _ = fsm.update(1.0, true);
-        // Second interactive tick: period=0.2 => 0.45
-        let _ = fsm.update(1.2, true);
-        assert_relative_eq!(fsm.prev_command(), 0.45);
-
-        // Leave to background: reset stores 0.45 for next entry
-        let _ = fsm.update(1.3, false); // decays output to 0.35, but reset kept 0.45
-        assert_eq!(fsm.mode(), Mode::Background);
-
-        // Re-enter interactive: should return stored 0.45 (not the decayed 0.35)
-        let out = fsm.update(2.0, true);
-        assert_eq!(fsm.mode(), Mode::Interactive);
-        assert_relative_eq!(out.unwrap(), 0.45);
-        assert_relative_eq!(fsm.prev_command(), 0.45);
+    pub fn update(&mut self, time: f64, is_interactive: bool) -> Option<f64> {
+        let period = time - self.prev_update_time;
+        match (self.mode) {
+            Mode::BeginRendering => self.update_begin_rendering(is_interactive),
+            Mode::Interactive => self.update_interactive(period, is_interactive),
+            Mode::Background => self.update_background(period, is_interactive),
+            Mode::Idle => self.update_idle(is_interactive),
+        }
     }
 }

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -88,7 +88,6 @@ where
     }
 
     fn update_begin_rendering(&mut self, is_interactive: bool) -> Option<f64> {
-        println!("FSM:   begin rendering");
         if is_interactive {
             self.mode = Mode::Interactive;
         } else {
@@ -103,7 +102,6 @@ where
         period: Option<f64>,
         is_interactive: bool,
     ) -> Option<f64> {
-        println!("FSM:   interactive");
         if !is_interactive {
             self.mode = Mode::Background;
         }
@@ -121,7 +119,6 @@ where
         period: Option<f64>,
         is_interactive: bool,
     ) -> Option<f64> {
-        println!("FSM:   background");
         if is_interactive {
             self.mode = Mode::Interactive;
         }
@@ -137,7 +134,6 @@ where
     }
 
     fn update_idle(&mut self, is_interactive: bool) -> Option<f64> {
-        println!("FSM:   idle");
         if is_interactive {
             self.mode = Mode::BeginRendering;
         }

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -107,17 +107,11 @@ where
         if !is_interactive {
             self.mode = Mode::Background;
         }
-        if period.is_none() {
-            // We're waiting on the result of an active render... No need to render.
-            return None;
-        }
-        if prev_command.is_none() {
-            println!("ERROR: period data was set, but there is no matching command!");
-            panic!();
-        }
+        let period = period?;
+        let prev_command = prev_command.expect("ERROR: period data was set, but there is no matching command!");
         let raw_command = self
             .interactive_policy
-            .evaluate(prev_command.unwrap(), period.unwrap());
+            .evaluate(prev_command, period);
         Some(F::clamp_command(raw_command))
     }
 
@@ -131,17 +125,11 @@ where
         if is_interactive {
             self.mode = Mode::Interactive;
         }
-        if period.is_none() {
-            // We're waiting on the result of an active render... No need to render.
-            return None;
-        }
-        if prev_command.is_none() {
-            println!("ERROR: period data was set, but there is no matching command!");
-            panic!();
-        }
+        let period = period?;
+        let prev_command = prev_command.expect("ERROR: period data was set, but there is no matching command!");
         let raw_render_command = self
             .background_policy
-            .evaluate(prev_command.unwrap(), period.unwrap());
+            .evaluate(prev_command, period);
         if raw_render_command <= 0.0 {
             self.mode = Mode::Idle;
         }

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -15,17 +15,17 @@
 // (5) use the same interface and design pattern for both interactive and background modes.
 
 
-// pub trait RenderQualityPolicy {
+pub trait RenderQualityPolicy {
 
-//     /// @param time: time right now. Used to compute frame rate.
-//     /// @return: render quality command (0 = maximum quality; 1 = maximum speed)
-//     ///     or None (indicating that the render pipeline should not run).
-//     fn evaluate(&mut self, time: f64, previous_command: f64) -> Option<f64>;
+    /// @param time: time right now. Used to compute frame rate.
+    /// @return: render quality command (0 = maximum quality; 1 = maximum speed)
+    ///     or None (indicating that the render pipeline should not run).
+    fn evaluate(&mut self, time: f64, previous_command: f64) -> Option<f64>;
 
-//     /// @param previous_command: value of the last non-trivial render command that was sent by any policy.
-//     fn on_entry(&mut self, previous_command: f64);
+    /// @param previous_command: value of the last non-trivial render command that was sent by any policy.
+    fn on_entry(&mut self, previous_command: f64);
 
-// }
+}
 
 use more_asserts::{assert_ge, assert_gt, assert_le};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -23,7 +23,7 @@ pub trait RenderQualityPolicy {
     }
 }
 
-use more_asserts::{assert_ge,  assert_le};
+use more_asserts::{assert_ge, assert_le};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
     BeginRendering,
@@ -66,7 +66,8 @@ where
         }
     }
 
-     fn update_begin_rendering(&mut self, is_interactive: bool) -> Option<f64> {
+    fn update_begin_rendering(&mut self, is_interactive: bool) -> Option<f64> {
+        println!("FSM:   begin rendering");
         if is_interactive {
             self.mode = Mode::Interactive;
         } else {
@@ -76,7 +77,8 @@ where
         Some(self.prev_render_command)
     }
 
-     fn update_interactive(&mut self, period: f64, is_interactive: bool) -> Option<f64> {
+    fn update_interactive(&mut self, period: f64, is_interactive: bool) -> Option<f64> {
+        println!("FSM:   interactive");
         if !is_interactive {
             self.mode = Mode::Background;
         }
@@ -88,7 +90,8 @@ where
         Some(self.prev_render_command)
     }
 
-     fn update_background(&mut self, period: f64, is_interactive: bool) -> Option<f64> {
+    fn update_background(&mut self, period: f64, is_interactive: bool) -> Option<f64> {
+        println!("FSM:   background");
         if is_interactive {
             self.mode = Mode::Interactive;
         }
@@ -102,7 +105,8 @@ where
         Some(self.prev_render_command)
     }
 
-     fn update_idle(&mut self, is_interactive: bool) -> Option<f64> {
+    fn update_idle(&mut self, is_interactive: bool) -> Option<f64> {
+        println!("FSM:   idle");
         if is_interactive {
             self.mode = Mode::BeginRendering;
         }
@@ -119,6 +123,5 @@ where
         }
     }
 }
-
 
 // TODO:  testing

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -7,6 +7,26 @@
 //! high quality, we should shut down the render pipeline to conserve
 //! resources (no need to spin at max CPU while idle...).
 
+
+// (1) updat the Interactive state to go back to the optional f64 for time. I realized that we always need the previous command.
+// (2) pass the previous command to the user policy (making it stateless)
+// (3) use the same generic interface for the "idle policy" (allow the user to pass in an idle and a interactive policy).
+// (4) make max delta an implementation detail of the user policies
+// (5) use the same interface and design pattern for both interactive and background modes.
+
+
+// pub trait RenderQualityPolicy {
+
+//     /// @param time: time right now. Used to compute frame rate.
+//     /// @return: render quality command (0 = maximum quality; 1 = maximum speed)
+//     ///     or None (indicating that the render pipeline should not run).
+//     fn evaluate(&mut self, time: f64, previous_command: f64) -> Option<f64>;
+
+//     /// @param previous_command: value of the last non-trivial render command that was sent by any policy.
+//     fn on_entry(&mut self, previous_command: f64);
+
+// }
+
 use more_asserts::{assert_ge, assert_gt, assert_le};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -1,0 +1,266 @@
+//! Simple FSM (finite state machine) that is used to regulate the
+//! render quality command for the render pipeline. While the user
+//! is actively interacting with the system, we want to hit a target
+//! frame rate, even if the render quality is low. However, once the
+//! user stops interacting, then we need to quickly crank up the render
+//! quality regardless of frame rate. Finally, once we've rendered at
+//! high quality, we should shut down the render pipeline to conserve
+//! resources (no need to spin at max CPU while idle...).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    Interactive,
+    Background,
+    Idle,
+}
+
+/// Per-mode continuous data for the Interactive mode.
+#[derive(Debug, Clone)]
+pub struct InteractiveData<F>
+where
+    F: Fn(f64, f64) -> f64,
+{
+    prev_time: Option<f64>,
+    command: f64,
+    get_interactive_command: F,
+}
+
+impl<F> InteractiveData<F>
+where
+    F: Fn(f64, f64) -> f64,
+{
+    pub fn new(initial_command: f64, get_interactive_command: F) -> Self {
+        // TODO: ensure on range [0,1] inclusive
+        debug_assert!(initial_command.is_finite(), "initial_command must be finite");
+        Self {
+            prev_time: None,
+            command: initial_command,
+            get_interactive_command,
+        }
+    }
+
+    // TODO:  add a reset method that is called on any transition out of this mode,
+    // which unsets the previouis time, so that on the first tick in the mode it
+    // will always just return the previous command.
+
+        // TODO: unused
+    pub fn command(&self) -> f64 { self.command }
+
+    // TODO:  rename to update
+    pub fn step(&mut self, time: f64, max_command_delta: f64) -> f64 {
+        let cmd = if let Some(prev_t) = self.prev_time {
+            let mut period = time - prev_t;
+            if !period.is_finite() || period < 0.0 {
+                period = 0.0;
+            }
+            (self.get_interactive_command)(period, max_command_delta)
+        } else {
+            self.command
+        };
+
+        self.prev_time = Some(time);
+        self.command = cmd;
+        cmd
+    }
+}
+
+#[derive(Debug)]
+pub struct Fsm<F>
+where
+    F: Fn(f64, f64) -> f64,
+{
+    mode: Mode,
+    prev_command: f64,
+    max_command_delta: f64,
+    interactive: InteractiveData<F>,
+}
+
+impl<F> Fsm<F>
+where
+    F: Fn(f64, f64) -> f64,
+{
+    /// Create a new FSM.
+    ///
+    /// - `initial_command` initializes both the global `prev_command` and the
+    ///   interactive state's `command`.
+    /// - `max_command_delta` must be finite and >= 0.0.
+    /// - `get_interactive_command(period, max_command_delta)` returns the interactive command.
+    pub fn new(initial_command: f64, max_command_delta: f64, get_interactive_command: F) -> Self {
+        debug_assert!(initial_command.is_finite(), "initial_command must be finite");
+        debug_assert!(max_command_delta.is_finite(), "max_command_delta must be finite");
+        debug_assert!(max_command_delta >= 0.0, "max_command_delta must be >= 0");
+
+        Self {
+            mode: Mode::Background,
+            prev_command: initial_command,
+            max_command_delta,
+            interactive: InteractiveData::new(initial_command, get_interactive_command),
+        }
+    }
+
+    pub fn mode(&self) -> Mode { self.mode }
+    pub fn prev_command(&self) -> f64 { self.prev_command }
+    pub fn interactive_data(&self) -> &InteractiveData<F> { &self.interactive }
+
+    /// Update the render FSM and return the render command, if any is needed.
+    pub fn update(&mut self, time: f64, is_interactive: bool) -> Option<f64> {
+        debug_assert!(time.is_finite(), "time must be finite");
+
+            // TODO: split up the transition and udpate of the FSM, each handled by a
+            // match statement. The first match does the transitions (discrete mode
+            // changes and reset logic), then the second performs actions.
+
+        if is_interactive {
+            // Enter/Remain Interactive
+            self.mode = Mode::Interactive;
+            let cmd = self.interactive.step(time, self.max_command_delta);
+            self.prev_command = cmd; // FSM-wide last command
+            return Some(cmd);
+        }
+
+        // Not interactive this tick
+        if self.mode == Mode::Interactive {
+            self.mode = Mode::Background;
+        }
+
+        match self.mode {
+            Mode::Background => self.step_background(),
+            Mode::Idle => None,
+            Mode::Interactive => unreachable!("handled above"),
+        }
+    }
+
+    /// Background behavior:
+    /// - Decay `prev_command` by `max_command_delta`.
+    /// - If still positive, stay in Background and return Some(next).
+    /// - If non-positive, move to Idle and return a final Some(0.0) once.
+    fn step_background(&mut self) -> Option<f64> {
+        let mut next = self.prev_command - self.max_command_delta;
+        if !next.is_finite() {
+            next = 0.0;
+        }
+
+        if next > 0.0 {
+            self.prev_command = next;
+            Some(next)
+        } else {
+            self.mode = Mode::Idle;
+            self.prev_command = 0.0;
+            Some(0.0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use more_asserts::{assert_ge, assert_le};
+
+    fn policy(period: f64, max_delta: f64) -> f64 {
+        // Example policy that uses both inputs:
+        // base = 2 * period; nudge by 0.5 * max_delta to show it's plumbed through.
+        2.0 * period + 0.5 * max_delta
+    }
+
+    #[test]
+    fn construction_defaults() {
+        let fsm = Fsm::new(0.3, 0.1, policy);
+        assert_eq!(fsm.mode(), Mode::Background);
+        assert_relative_eq!(fsm.prev_command(), 0.3);
+        assert!(fsm.interactive_data().prev_time().is_none());
+        assert_relative_eq!(fsm.interactive_data().command(), 0.3);
+        assert_ge!(fsm.prev_command(), 0.0);
+    }
+
+    #[test]
+    fn first_interactive_tick_uses_previous_interactive_command() {
+        let mut fsm = Fsm::new(0.3, 0.1, policy);
+        let out = fsm.update(1.0, true); // interactive
+        assert_eq!(fsm.mode(), Mode::Interactive);
+        assert!(fsm.interactive_data().prev_time().is_some());
+        assert_relative_eq!(out.unwrap(), 0.3);
+        assert_relative_eq!(fsm.prev_command(), 0.3);
+    }
+
+    #[test]
+    fn interactive_period_computes_policy_command() {
+        let mut fsm = Fsm::new(0.3, 0.1, policy);
+        let _ = fsm.update(1.0, true); // first interactive tick returns prior interactive cmd
+        // Next tick: period=0.1 => cmd = 2*0.1 + 0.5*0.1 = 0.2 + 0.05 = 0.25
+        let out = fsm.update(1.1, true);
+        assert_eq!(fsm.mode(), Mode::Interactive);
+        assert_relative_eq!(out.unwrap(), 0.25);
+        assert_relative_eq!(fsm.interactive_data().command(), 0.25);
+        assert_relative_eq!(fsm.prev_command(), 0.25);
+        assert_ge!(fsm.prev_command(), 0.0);
+        assert_le!(fsm.prev_command(), 10.0); // arbitrary sanity guard
+    }
+
+    #[test]
+    fn interactive_nonmonotonic_time_is_clamped() {
+        let mut fsm = Fsm::new(0.3, 0.2, policy);
+        let _ = fsm.update(2.0, true); // first interactive tick
+        // time went backwards -> period clamped to 0 => cmd = 2*0 + 0.5*0.2 = 0.1
+        let out = fsm.update(1.9, true);
+        assert_relative_eq!(out.unwrap(), 0.1);
+        assert_relative_eq!(fsm.prev_command(), 0.1);
+        assert_relative_eq!(fsm.interactive_data().command(), 0.1);
+    }
+
+    #[test]
+    fn interactive_to_background_then_decay() {
+        let mut fsm = Fsm::new(0.3, 0.1, policy);
+        let _ = fsm.update(1.0, true); // returns 0.3
+        // period=0.2 => cmd=2*0.2+0.05=0.45
+        let _ = fsm.update(1.2, true);
+        assert_relative_eq!(fsm.prev_command(), 0.45);
+
+        // Flag goes false -> transition to background and decay in same tick
+        let out = fsm.update(1.3, false);
+        assert_eq!(fsm.mode(), Mode::Background);
+        assert_relative_eq!(out.unwrap(), 0.35); // 0.45 - 0.1
+        assert_relative_eq!(fsm.prev_command(), 0.35);
+
+        // Decay again (still background)
+        let out2 = fsm.update(1.4, false);
+        assert_eq!(fsm.mode(), Mode::Background);
+        assert_relative_eq!(out2.unwrap(), 0.25);
+        assert_relative_eq!(fsm.prev_command(), 0.25);
+    }
+
+    #[test]
+    fn background_to_idle_on_zero_crossing() {
+        let mut fsm = Fsm::new(0.15, 0.1, policy);
+        assert_eq!(fsm.mode(), Mode::Background);
+
+        // 0.15 -> 0.05
+        let out1 = fsm.update(10.0, false);
+        assert_eq!(fsm.mode(), Mode::Background);
+        assert_relative_eq!(out1.unwrap(), 0.05);
+        // 0.05 -> 0.00, transitions to Idle and returns a final 0.0 once
+        let out2 = fsm.update(11.0, false);
+        assert_eq!(fsm.mode(), Mode::Idle);
+        assert_relative_eq!(out2.unwrap(), 0.0);
+        assert_relative_eq!(fsm.prev_command(), 0.0);
+    }
+
+    #[test]
+    fn idle_returns_none_until_interactive() {
+        let mut fsm = Fsm::new(0.05, 0.1, policy);
+        // Background -> immediate decay to 0 -> Idle
+        let _ = fsm.update(0.0, false); // 0.05 -> 0.0 & idle
+        assert_eq!(fsm.mode(), Mode::Idle);
+
+        // Idle returns None (no command)
+        let out_none = fsm.update(1.0, false);
+        assert!(out_none.is_none());
+        assert_relative_eq!(fsm.prev_command(), 0.0);
+
+        // Any-state -> Interactive when flag set
+        let out_interactive = fsm.update(2.0, true);
+        assert_eq!(fsm.mode(), Mode::Interactive);
+        // First interactive tick uses previous interactive command (which was initial 0.05)
+        assert_relative_eq!(out_interactive.unwrap(), 0.05);
+        assert_relative_eq!(fsm.prev_command(), 0.05);
+    }
+}

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -125,7 +125,6 @@ where
         pixel_grid
             .view_control
             .update(time, center_command, ZoomVelocityCommand::zero());
-        // pixel_grid.render();
         pixel_grid
     }
 

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -106,7 +106,7 @@ where
         // HACK -- render pipeline parameters
         let initial_render_command = 0.0;
         let target_update_period = 1.0 / 24.0;
-        let max_command_delta = 0.1;
+        let max_command_delta = 0.05;
 
         let mut pixel_grid = Self {
             display_buffer: Arc::new(Mutex::new(display_buffer)),

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -5,15 +5,13 @@ use std::sync::{
 
 use image::Rgb;
 
+use crate::core::controller::AdaptiveOptimizationRegulator;
+
 use super::{
     file_io::{date_time_string, serialize_to_json_or_panic, FilePrefix},
     image_utils::{create_buffer, write_image_to_file_or_panic, ImageSpecification, Renderable},
     view_control::{CenterCommand, CenterTargetCommand, ViewControl, ZoomVelocityCommand},
 };
-
-// For now, jump to an intermediate render quality while interacting to make for a
-// responsive UI. Eventually we'll replace this with an adaptive controller.
-const SPEED_OPTIMIZATION_LEVEL_WHILE_INTERACTING: f64 = 0.5;
 
 /// A trait for managing and rendering a graphical view with controls for recentering,
 /// panning, zooming, updating, and saving the rendered output. This is the core interface
@@ -71,6 +69,12 @@ pub struct PixelGrid<F: Renderable> {
     // images to disk while exploring the fractal.
     file_prefix: FilePrefix,
 
+    // Measures the render speed on each redraw, and then uses that to adaptively change
+    // the trade-off between render quality and speed. Once the user stops interacting,
+    // the quality will gradually increase, resulting in a progressively better render.
+    // While interacting, this ensures that we have a fast response from the graphics.
+    adaptive_quality_regulator: AdaptiveOptimizationRegulator,
+
     // Encapsulates all details required to render the image.
     // Wrapped in an `Arc<Mutex<>>` to enable render in a background thread.
     renderer: Arc<Mutex<F>>,
@@ -113,6 +117,7 @@ where
             render_task_is_busy: Arc::new(AtomicBool::new(false)),
             render_required: Some(0.0),
             redraw_required: Arc::new(AtomicBool::new(false)),
+            adaptive_quality_regulator: AdaptiveOptimizationRegulator::new(time),
         };
         pixel_grid
             .view_control
@@ -169,7 +174,8 @@ where
         // is a lock that is used to ensure that we only attempt one render at a time, as
         // this task will use all available CPU resources.
         if self.view_control.update(time, center_command, zoom_command) {
-            self.render_required = Some(SPEED_OPTIMIZATION_LEVEL_WHILE_INTERACTING);
+            // Recompute the "render level" whenever the usere modifies the view port...
+            self.render_required = Some(self.adaptive_quality_regulator.interactive_update(time));
         }
         if let Some(level) = self.render_required {
             if !self.render_task_is_busy.swap(true, Ordering::Acquire) {
@@ -178,13 +184,11 @@ where
                     .unwrap()
                     .set_speed_optimization_level(level, &self.speed_optimizer_cache);
                 self.render();
-                if level > 0.0 {
-                    // HACK:  asymtotiallcy approach zero  (maximum quality)
-                    // We'll fix this properly in a follow-up project.
-                    self.render_required = Some(0.5 * level);
-                } else {
-                    self.render_required = None;
-                }
+                // Also recompute the "render level" when the render completes...
+                // Problem: this is an "inactive update". The view port has not changed and the user is
+                // not waiting on a responsive UI.  Now we should switch the focus and instead just
+                // gradually work on increasing the quality of the image in-place.
+                self.render_required = self.adaptive_quality_regulator.idle_update(time);
             }
         }
 

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -125,7 +125,7 @@ where
         pixel_grid
             .view_control
             .update(time, center_command, ZoomVelocityCommand::zero());
-        pixel_grid.render();
+        // pixel_grid.render();
         pixel_grid
     }
 

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -6,10 +6,10 @@ use std::sync::{
 use image::Rgb;
 
 use super::{
+    controller::AdaptiveOptimizationRegulator,
     file_io::{date_time_string, serialize_to_json_or_panic, FilePrefix},
     image_utils::{create_buffer, write_image_to_file_or_panic, ImageSpecification, Renderable},
     view_control::{CenterCommand, CenterTargetCommand, ViewControl, ZoomVelocityCommand},
-    controller::AdaptiveOptimizationRegulator,
 };
 
 /// A trait for managing and rendering a graphical view with controls for recentering,
@@ -172,7 +172,7 @@ where
         // be copied to the screen using the `draw` method. The `render_task_is_busy` flag
         // is a lock that is used to ensure that we only attempt one render at a time, as
         // this task will use all available CPU resources.
-        let user_interaction =self.view_control.update(time, center_command, zoom_command);
+        let user_interaction = self.view_control.update(time, center_command, zoom_command);
         if let Some(level) = self.render_required {
             if !self.render_task_is_busy.swap(true, Ordering::Acquire) {
                 self.renderer
@@ -184,7 +184,9 @@ where
                 // Problem: this is an "inactive update". The view port has not changed and the user is
                 // not waiting on a responsive UI.  Now we should switch the focus and instead just
                 // gradually work on increasing the quality of the image in-place.
-                self.render_required = self.adaptive_quality_regulator.update(time, user_interaction);
+                self.render_required = self
+                    .adaptive_quality_regulator
+                    .update(time, user_interaction);
             }
         }
 

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -5,12 +5,11 @@ use std::sync::{
 
 use image::Rgb;
 
-use crate::core::controller::AdaptiveOptimizationRegulator;
-
 use super::{
     file_io::{date_time_string, serialize_to_json_or_panic, FilePrefix},
     image_utils::{create_buffer, write_image_to_file_or_panic, ImageSpecification, Renderable},
     view_control::{CenterCommand, CenterTargetCommand, ViewControl, ZoomVelocityCommand},
+    controller::AdaptiveOptimizationRegulator,
 };
 
 /// A trait for managing and rendering a graphical view with controls for recentering,
@@ -173,10 +172,7 @@ where
         // be copied to the screen using the `draw` method. The `render_task_is_busy` flag
         // is a lock that is used to ensure that we only attempt one render at a time, as
         // this task will use all available CPU resources.
-        if self.view_control.update(time, center_command, zoom_command) {
-            // Recompute the "render level" whenever the usere modifies the view port...
-            self.render_required = Some(self.adaptive_quality_regulator.interactive_update(time));
-        }
+        let user_interaction =self.view_control.update(time, center_command, zoom_command);
         if let Some(level) = self.render_required {
             if !self.render_task_is_busy.swap(true, Ordering::Acquire) {
                 self.renderer
@@ -188,7 +184,7 @@ where
                 // Problem: this is an "inactive update". The view port has not changed and the user is
                 // not waiting on a responsive UI.  Now we should switch the focus and instead just
                 // gradually work on increasing the quality of the image in-place.
-                self.render_required = self.adaptive_quality_regulator.idle_update(time);
+                self.render_required = self.adaptive_quality_regulator.update(time, user_interaction);
             }
         }
 

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -107,6 +107,11 @@ where
 
         let renderer = Arc::new(Mutex::new(renderer));
 
+        // HACK -- render pipeline parameters
+        let initial_render_command = 0.0;
+        let target_update_period = 1.0 / 24.0;
+        let max_command_delta = 0.1;
+
         let mut pixel_grid = Self {
             display_buffer: Arc::new(Mutex::new(display_buffer)),
             view_control,
@@ -116,7 +121,9 @@ where
             render_task_is_busy: Arc::new(AtomicBool::new(false)),
             render_required: Some(0.0),
             redraw_required: Arc::new(AtomicBool::new(false)),
-            adaptive_quality_regulator: AdaptiveOptimizationRegulator::new(time),
+            adaptive_quality_regulator: AdaptiveOptimizationRegulator::new(     initial_render_command,
+         target_update_period,
+         max_command_delta),
         };
         pixel_grid
             .view_control


### PR DESCRIPTION
WORK IN PROGRESS

Adds a controller that computes the "quality level" for each render as a function of the measured period for the previous render (and what that quality level was). This turned out to be a bit more complicated than expected, because there are some edge cases to worry about, for example, when the user stops interacting we want to render at high quality and then pause the render pipeline.

**Status as of 2025-08-21:** It works!  But the code is a mess and the algorithm is more complicated than needed. I'm planning to do some clean-up passes on the code, and also try to tweak the parameters and algorithm a bit to improve the overall performance of the feature.