### PR TITLE
Add the Render Quality FSM

### DIFF
--- a/examples/julia/default.json
+++ b/examples/julia/default.json
@@ -33,11 +33,11 @@
       "lookup_table_count": 2048,
       "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
-      "histogram_sample_count": 50000
+      "histogram_sample_count": 40000
     },
     "render_options": {
       "downsample_stride": 1,
-      "subpixel_antialiasing": 3
+      "subpixel_antialiasing": 2
     }
   }
 }

--- a/examples/julia/default.json
+++ b/examples/julia/default.json
@@ -33,11 +33,11 @@
       "lookup_table_count": 2048,
       "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
-      "histogram_sample_count": 40000
+      "histogram_sample_count": 50000
     },
     "render_options": {
       "downsample_stride": 1,
-      "subpixel_antialiasing": 0
+      "subpixel_antialiasing": 3
     }
   }
 }

--- a/src/core/controller.rs
+++ b/src/core/controller.rs
@@ -1,5 +1,3 @@
-use crate::core::render_quality_fsm::{self, ConstantFrameRatePolicy, FiniteStateMachine};
-
 #[derive(Clone, Debug)]
 pub enum Target {
     Position { pos_ref: f64, max_vel: f64 },
@@ -70,93 +68,6 @@ impl PointTracker {
             Target::Velocity { vel_ref } => {
                 self.position += vel_ref * delta_time;
             }
-        }
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////
-
-/// The `AdaptiveOptimizationRegulator` is a simple class wrapping a finite state machine
-/// that is used to compute the "render quality" (0 = high quality but slow, 1 = low quality
-/// but fast), while exploring a fractal interactively with the user.
-#[derive(Clone, Debug)]
-pub struct AdaptiveOptimizationRegulator {
-    render_policy_fsm:
-        render_quality_fsm::FiniteStateMachine<ConstantFrameRatePolicy, ConstantFrameRatePolicy>,
-    render_start_time: Option<f64>,
-    render_period: Option<f64>,
-    render_command: Option<f64>,
-}
-
-/// For now, keep the regulator simple with some hard-coded policies.
-/// Eventually these will be replaced with policies that depend on the
-/// measured frame rate data.
-impl Default for AdaptiveOptimizationRegulator {
-    fn default() -> Self {
-        Self {
-            render_policy_fsm: FiniteStateMachine::new(
-                0.0,
-                ConstantFrameRatePolicy::new(0.55),
-                ConstantFrameRatePolicy::new(0.0),
-            ),
-            render_start_time: None,
-            render_period: None,
-            render_command: None,
-        }
-    }
-}
-
-impl AdaptiveOptimizationRegulator {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn reset(&mut self) {
-        self.render_policy_fsm.reset();
-        self.render_start_time = None;
-        self.render_period = None;
-        self.render_command = None;
-    }
-
-    /// This method is called each time that the `explore` pipeline would like
-    /// to render the fractal. It returns an optional value, which, if set,
-    /// indicates that the fractal should be rendered, and the floating point
-    /// value specifies the render quality value. If unset, in indicates that the
-    /// fractal already has been rendered to the screen, and does not need to be
-    /// recomputed, allowing the system to save resources.
-    pub fn render_required(&mut self, is_interactive: bool) -> Option<f64> {
-        self.render_policy_fsm.render_required(
-            self.render_command,
-            self.render_period,
-            is_interactive,
-        )
-    }
-
-    /// Called by the render pipeline whenever a new render begins.
-    /// This is a separate method from `render_required` because we cannot
-    /// run two renders at once, and the rendering happens in a separate
-    /// background process. This method will be called immediately at the
-    /// start of each enw render, and is used to collect accurate timing
-    /// data for the finite state machine logic. It caches that data for
-    /// use in the `render_required` method.
-    pub fn begin_rendering(&mut self, time: f64, command: f64) {
-        self.render_start_time = Some(time);
-        self.render_period = None;
-        self.render_command = Some(command);
-    }
-
-    /// Called by the render pipeline whenever the render is completed.
-    /// This is the matched method to the `begin_rendering` method, and
-    /// is used for accurate data collection on the frame rate. This method
-    /// should be called whenever the background thread finishes a render.
-    pub fn finish_rendering(&mut self, time: f64) {
-        // Note: this method will sometimes be called twice for a single
-        // `begin_rendering` call because the redrawing can take a long time.
-        // For this reason, we guard the update here, only updating the data
-        // on the first time that finish is called after begin.
-        if let Some(start_time) = self.render_start_time {
-            self.render_period = Some(time - start_time);
-            self.render_start_time = None;
         }
     }
 }

--- a/src/core/image_utils.rs
+++ b/src/core/image_utils.rs
@@ -8,7 +8,7 @@ use std::{
     path::PathBuf,
 };
 
-use crate::core::interpolation::{Interpolator, LinearInterpolator};
+use crate::core::interpolation::{ClampedLinearInterpolator, Interpolator};
 
 use super::file_io::{serialize_to_json_or_panic, FilePrefix};
 use super::stopwatch::Stopwatch;
@@ -192,6 +192,7 @@ pub struct RenderOptions {
 }
 
 const MAX_DOWNSAMPLE_STRIDE: f64 = 8.0;
+const MIN_DOWNSAMPLE_STRIDE: f64 = 1.0;
 
 impl SpeedOptimizer for RenderOptions {
     type ReferenceCache = RenderOptions;
@@ -201,11 +202,25 @@ impl SpeedOptimizer for RenderOptions {
     }
 
     fn set_speed_optimization_level(&mut self, level: f64, cache: &Self::ReferenceCache) {
-        // Note:  1.0 = no downsample stride (one sample per pixel)
-        self.downsample_stride =
-            LinearInterpolator.interpolate(level, 1.0, MAX_DOWNSAMPLE_STRIDE) as usize;
-        self.subpixel_antialiasing =
-            LinearInterpolator.interpolate(level, cache.subpixel_antialiasing as f64, 0.0) as u32;
+        // Downsample stride has effective, but hugely reduces image quality and produces large jumps in the
+        // render pipeline duration. It is better to rely on other things like reducing the iteration counts
+        // before falling back to this. To do that, let's modify the level so that is doesn't "turn on"
+        // until it hits some non-zero value.
+        let delayed_activation_level = (level * 2.0) - 1.0;
+        self.downsample_stride = ClampedLinearInterpolator.interpolate(
+            delayed_activation_level,
+            MIN_DOWNSAMPLE_STRIDE,
+            MAX_DOWNSAMPLE_STRIDE,
+        ) as usize;
+
+        // Antialiasing is super expensive, and not too visible while panning around. We should turn it off
+        // really quickly once we need to render faster.
+        let fast_drop_off_level = 5.0 * level;
+        self.subpixel_antialiasing = ClampedLinearInterpolator.interpolate(
+            fast_drop_off_level,
+            cache.subpixel_antialiasing as f64,
+            0.0,
+        ) as u32;
     }
 }
 

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -149,7 +149,6 @@ where
 }
 
 /// Clamped Linear interpolation: low * (1 - alpha.clamp(0,1)) + upp * alpha)
-///
 #[derive(Default, Clone, Copy, Debug)]
 pub struct ClampedLinearInterpolator;
 
@@ -163,7 +162,7 @@ where
     /// - `low`: lower bound on interpolation; returned if `alpha == 0.0`
     /// - `upp`: upper bound on interpolation; returned if `alpha == 1.0`
     ///
-    /// Note:  this method will *extrapolate* if `alpha` is not in [0,1]
+    /// Note:  this method will clamp `alpha` to [0,1] --> [low, upp].
     fn interpolate(&self, alpha: T, low: V, upp: V) -> V {
         if alpha <= T::zero() {
             return low;

--- a/src/core/interpolation.rs
+++ b/src/core/interpolation.rs
@@ -59,16 +59,6 @@ where
     }
 
     #[cfg(test)]
-    pub fn queries(&self) -> &[T] {
-        &self.queries
-    }
-
-    #[cfg(test)]
-    pub fn values(&self) -> &[V] {
-        &self.values
-    }
-
-    #[cfg(test)]
     pub fn set_keyframe_query(&mut self, index: usize, query: T) {
         assert!(
             index < self.queries.len(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ pub mod image_utils;
 pub mod interpolation;
 pub mod lookup_table;
 pub mod ode_solvers;
+pub mod render_quality_fsm;
 pub mod render_window;
 pub mod stopwatch;
 pub mod view_control;

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -1,12 +1,3 @@
-//! Simple FSM (finite state machine) that is used to regulate the
-//! render quality command for the render pipeline. While the user
-//! is actively interacting with the system, we want to hit a target
-//! frame rate, even if the render quality is low. However, once the
-//! user stops interacting, then we need to quickly crank up the render
-//! quality regardless of frame rate. Finally, once we've rendered at
-//! high quality, we should shut down the render pipeline to conserve
-//! resources (no need to spin at max CPU while idle...).
-
 pub trait RenderQualityPolicy {
     const MAX_COMMAND: f64 = 1.0;
     const MIN_COMMAND: f64 = 0.0;
@@ -51,6 +42,14 @@ pub enum Mode {
     Idle,
 }
 
+/// Simple FSM (finite state machine) that is used to regulate the
+/// render quality command for the render pipeline. While the user
+/// is actively interacting with the system, we want to hit a target
+/// frame rate, even if the render quality is low. However, once the
+/// user stops interacting, then we need to quickly crank up the render
+/// quality regardless of frame rate. Finally, once we've rendered at
+/// high quality, we should shut down the render pipeline to conserve
+/// resources (no need to spin at max CPU while idle...).
 #[derive(Debug, Clone)]
 pub struct FiniteStateMachine<F, G>
 where
@@ -163,6 +162,92 @@ where
             Some(self.previous_interactive_render_command)
         } else {
             None
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+
+/// The `AdaptiveOptimizationRegulator` is a simple class wrapping a finite state machine
+/// that is used to compute the "render quality" (0 = high quality but slow, 1 = low quality
+/// but fast), while exploring a fractal interactively with the user.
+#[derive(Clone, Debug)]
+pub struct AdaptiveOptimizationRegulator {
+    render_policy_fsm: FiniteStateMachine<ConstantFrameRatePolicy, ConstantFrameRatePolicy>,
+    render_start_time: Option<f64>,
+    render_period: Option<f64>,
+    render_command: Option<f64>,
+}
+
+/// For now, keep the regulator simple with some hard-coded policies.
+/// Eventually these will be replaced with policies that depend on the
+/// measured frame rate data.
+impl Default for AdaptiveOptimizationRegulator {
+    fn default() -> Self {
+        Self {
+            render_policy_fsm: FiniteStateMachine::new(
+                0.0,
+                ConstantFrameRatePolicy::new(0.55),
+                ConstantFrameRatePolicy::new(0.0),
+            ),
+            render_start_time: None,
+            render_period: None,
+            render_command: None,
+        }
+    }
+}
+
+impl AdaptiveOptimizationRegulator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reset(&mut self) {
+        self.render_policy_fsm.reset();
+        self.render_start_time = None;
+        self.render_period = None;
+        self.render_command = None;
+    }
+
+    /// This method is called each time that the `explore` pipeline would like
+    /// to render the fractal. It returns an optional value, which, if set,
+    /// indicates that the fractal should be rendered, and the floating point
+    /// value specifies the render quality value. If unset, in indicates that the
+    /// fractal already has been rendered to the screen, and does not need to be
+    /// recomputed, allowing the system to save resources.
+    pub fn render_required(&mut self, is_interactive: bool) -> Option<f64> {
+        self.render_policy_fsm.render_required(
+            self.render_command,
+            self.render_period,
+            is_interactive,
+        )
+    }
+
+    /// Called by the render pipeline whenever a new render begins.
+    /// This is a separate method from `render_required` because we cannot
+    /// run two renders at once, and the rendering happens in a separate
+    /// background process. This method will be called immediately at the
+    /// start of each enw render, and is used to collect accurate timing
+    /// data for the finite state machine logic. It caches that data for
+    /// use in the `render_required` method.
+    pub fn begin_rendering(&mut self, time: f64, command: f64) {
+        self.render_start_time = Some(time);
+        self.render_period = None;
+        self.render_command = Some(command);
+    }
+
+    /// Called by the render pipeline whenever the render is completed.
+    /// This is the matched method to the `begin_rendering` method, and
+    /// is used for accurate data collection on the frame rate. This method
+    /// should be called whenever the background thread finishes a render.
+    pub fn finish_rendering(&mut self, time: f64) {
+        // Note: this method will sometimes be called twice for a single
+        // `begin_rendering`, so we add this guard while will only update
+        // the period on the first call to `finish_rendering()` after calling
+        // `begin_rendering()`.
+        if let Some(start_time) = self.render_start_time {
+            self.render_period = Some(time - start_time);
+            self.render_start_time = None;
         }
     }
 }

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -68,7 +68,7 @@ where
     F: RenderQualityPolicy,
     G: RenderQualityPolicy,
 {
-    /// Create a new FSM for regularing the render quality.
+    /// Create a new FSM for regulating the render quality.
     pub fn new(initial_command: f64, interactive_policy: F, background_policy: G) -> Self {
         assert_ge!(initial_command, 0.0);
         assert_le!(initial_command, 1.0);
@@ -251,6 +251,3 @@ impl AdaptiveOptimizationRegulator {
         }
     }
 }
-
-// TODO:  testing
-// ON transition from IDLE to Begin, we run with the last interactive command

--- a/src/core/render_quality_fsm.rs
+++ b/src/core/render_quality_fsm.rs
@@ -1,0 +1,171 @@
+//! Simple FSM (finite state machine) that is used to regulate the
+//! render quality command for the render pipeline. While the user
+//! is actively interacting with the system, we want to hit a target
+//! frame rate, even if the render quality is low. However, once the
+//! user stops interacting, then we need to quickly crank up the render
+//! quality regardless of frame rate. Finally, once we've rendered at
+//! high quality, we should shut down the render pipeline to conserve
+//! resources (no need to spin at max CPU while idle...).
+
+pub trait RenderQualityPolicy {
+    const MAX_COMMAND: f64 = 1.0;
+    const MIN_COMMAND: f64 = 0.0;
+
+    /// @param previous_command: last render command that was completed
+    /// @param measured_period: how long did that render command take to complete?
+    /// @return: render quality command (0 = maximum quality; 1 = maximum speed)
+    ///     out of bound commands will be clamped to [0,1]
+    fn evaluate(&mut self, previous_command: f64, measured_period: f64) -> f64;
+
+    fn clamp_command(command: f64) -> f64 {
+        command.clamp(Self::MIN_COMMAND, Self::MAX_COMMAND)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ConstantFrameRatePolicy {
+    /// The command to always return (clamped in `evaluate`).
+    value: f64,
+}
+
+impl ConstantFrameRatePolicy {
+    pub fn new(value: f64) -> Self {
+        Self {
+            value: <Self as RenderQualityPolicy>::clamp_command(value),
+        }
+    }
+}
+
+impl RenderQualityPolicy for ConstantFrameRatePolicy {
+    fn evaluate(&mut self, _previous_command: f64, _measured_period: f64) -> f64 {
+        self.value
+    }
+}
+
+use more_asserts::{assert_ge, assert_le};
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    BeginRendering,
+    Interactive,
+    Background,
+    Idle,
+}
+
+#[derive(Debug, Clone)]
+pub struct FiniteStateMachine<F, G>
+where
+    F: RenderQualityPolicy,
+    G: RenderQualityPolicy,
+{
+    mode: Mode,                  // which mode are we in right now?
+    initial_render_command: f64, // what is the command to send when we first start rendering?
+    interactive_policy: F,
+    background_policy: G,
+    previous_interactive_render_command: f64,
+}
+
+impl<F, G> FiniteStateMachine<F, G>
+where
+    F: RenderQualityPolicy,
+    G: RenderQualityPolicy,
+{
+    /// Create a new FSM for regularing the render quality.
+    pub fn new(initial_command: f64, interactive_policy: F, background_policy: G) -> Self {
+        assert_ge!(initial_command, 0.0);
+        assert_le!(initial_command, 1.0);
+        let initial_command = initial_command.clamp(0.0, 1.0);
+        Self {
+            mode: Mode::BeginRendering,
+            initial_render_command: initial_command,
+            interactive_policy,
+            background_policy,
+            previous_interactive_render_command: initial_command,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.mode = Mode::BeginRendering;
+        self.previous_interactive_render_command = self.initial_render_command;
+    }
+
+    /// @param previous_render_command: previous render command, if one has been set
+    /// @param render_period: if the command has been completed, how long did it take?
+    /// @param is_interactive:  is the user interacting with the fractal view port?
+    pub fn render_required(
+        &mut self,
+        previous_render_command: Option<f64>,
+        render_period: Option<f64>,
+        is_interactive: bool,
+    ) -> Option<f64> {
+        match self.mode {
+            Mode::BeginRendering => self.update_begin_rendering(is_interactive),
+            Mode::Interactive => {
+                self.update_interactive(previous_render_command, render_period, is_interactive)
+            }
+            Mode::Background => {
+                self.update_background(previous_render_command, render_period, is_interactive)
+            }
+            Mode::Idle => self.update_idle(is_interactive),
+        }
+    }
+
+    fn update_begin_rendering(&mut self, is_interactive: bool) -> Option<f64> {
+        if is_interactive {
+            self.mode = Mode::Interactive;
+        } else {
+            self.mode = Mode::Background;
+        }
+        Some(self.previous_interactive_render_command)
+    }
+
+    fn update_interactive(
+        &mut self,
+        _: Option<f64>,
+        period: Option<f64>,
+        is_interactive: bool,
+    ) -> Option<f64> {
+        if !is_interactive {
+            self.mode = Mode::Background;
+        }
+        let period = period?;
+        // Note:  here we use the previous *interactive* command, rather than the
+        // general previous command across all modes. This is intentional -- it means
+        // that the GUI is responsive when we resume from a period of non-interaction.
+        let raw_command = self
+            .interactive_policy
+            .evaluate(self.previous_interactive_render_command, period);
+        self.previous_interactive_render_command = F::clamp_command(raw_command);
+        Some(self.previous_interactive_render_command)
+    }
+
+    fn update_background(
+        &mut self,
+        prev_command: Option<f64>,
+        period: Option<f64>,
+        is_interactive: bool,
+    ) -> Option<f64> {
+        if is_interactive {
+            self.mode = Mode::Interactive;
+        }
+        let period = period?;
+        let prev_command =
+            prev_command.expect("ERROR: period data was set, but there is no matching command!");
+        let raw_render_command = self.background_policy.evaluate(prev_command, period);
+        if raw_render_command <= 0.0 {
+            self.mode = Mode::Idle;
+        }
+        Some(G::clamp_command(raw_render_command))
+    }
+
+    fn update_idle(&mut self, is_interactive: bool) -> Option<f64> {
+        if is_interactive {
+            self.mode = Mode::Interactive;
+            Some(self.previous_interactive_render_command)
+        } else {
+            None
+        }
+    }
+}
+
+// TODO:  testing
+// ON transition from IDLE to Begin, we run with the last interactive command

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -6,14 +6,11 @@ use std::sync::{
 use image::Rgb;
 
 use super::{
+    controller::AdaptiveOptimizationRegulator,
     file_io::{date_time_string, serialize_to_json_or_panic, FilePrefix},
     image_utils::{create_buffer, write_image_to_file_or_panic, ImageSpecification, Renderable},
     view_control::{CenterCommand, CenterTargetCommand, ViewControl, ZoomVelocityCommand},
 };
-
-// For now, jump to an intermediate render quality while interacting to make for a
-// responsive UI. Eventually we'll replace this with an adaptive controller.
-const SPEED_OPTIMIZATION_LEVEL_WHILE_INTERACTING: f64 = 0.5;
 
 /// A trait for managing and rendering a graphical view with controls for recentering,
 /// panning, zooming, updating, and saving the rendered output. This is the core interface
@@ -71,6 +68,12 @@ pub struct PixelGrid<F: Renderable> {
     // images to disk while exploring the fractal.
     file_prefix: FilePrefix,
 
+    // Measures the render speed on each redraw, and then uses that to adaptively change
+    // the trade-off between render quality and speed. Once the user stops interacting,
+    // the quality will gradually increase, resulting in a progressively better render.
+    // While interacting, this ensures that we have a fast response from the graphics.
+    adaptive_quality_regulator: AdaptiveOptimizationRegulator,
+
     // Encapsulates all details required to render the image.
     // Wrapped in an `Arc<Mutex<>>` to enable render in a background thread.
     renderer: Arc<Mutex<F>>,
@@ -80,10 +83,6 @@ pub struct PixelGrid<F: Renderable> {
 
     // Lock, used to ensure that we only run a single render background task.
     render_task_is_busy: Arc<AtomicBool>,
-
-    // This flag is set high when we need to trigger another render pass.
-    // If set, then it contains the desired speed optimization level for the render.
-    render_required: Option<f64>,
 
     // Set to `true` when rendering is complete and the display buffer needs
     // to be copied to the screen.
@@ -103,7 +102,6 @@ where
         });
 
         let renderer = Arc::new(Mutex::new(renderer));
-
         let mut pixel_grid = Self {
             display_buffer: Arc::new(Mutex::new(display_buffer)),
             view_control,
@@ -111,13 +109,12 @@ where
             renderer: renderer.clone(),
             speed_optimizer_cache: renderer.lock().unwrap().reference_cache(),
             render_task_is_busy: Arc::new(AtomicBool::new(false)),
-            render_required: Some(0.0),
             redraw_required: Arc::new(AtomicBool::new(false)),
+            adaptive_quality_regulator: AdaptiveOptimizationRegulator::new(),
         };
         pixel_grid
             .view_control
             .update(time, center_command, ZoomVelocityCommand::zero());
-        pixel_grid.render();
         pixel_grid
     }
 
@@ -150,7 +147,7 @@ where
 
     fn reset(&mut self) {
         self.view_control.reset();
-        self.render_required = Some(0.0);
+        self.adaptive_quality_regulator.reset();
     }
 
     fn update(
@@ -168,27 +165,31 @@ where
         // be copied to the screen using the `draw` method. The `render_task_is_busy` flag
         // is a lock that is used to ensure that we only attempt one render at a time, as
         // this task will use all available CPU resources.
-        if self.view_control.update(time, center_command, zoom_command) {
-            self.render_required = Some(SPEED_OPTIMIZATION_LEVEL_WHILE_INTERACTING);
-        }
-        if let Some(level) = self.render_required {
+
+        // There are two reasons that we might want to render the fractal:
+        // (1) the view control reports that user-interaction has changed the view port onto the fractal
+        // (2) the adaptive quality regulator reports that the render quality needs to be modified
+        let user_interaction = self.view_control.update(time, center_command, zoom_command);
+        let render_required = self
+            .adaptive_quality_regulator
+            .render_required(user_interaction);
+        if let Some(command) = render_required {
             if !self.render_task_is_busy.swap(true, Ordering::Acquire) {
                 self.renderer
                     .lock()
                     .unwrap()
-                    .set_speed_optimization_level(level, &self.speed_optimizer_cache);
+                    .set_speed_optimization_level(command, &self.speed_optimizer_cache);
+                self.adaptive_quality_regulator
+                    .begin_rendering(time, command);
+                println!("Rendering now at level = {}...", command);
                 self.render();
-                if level > 0.0 {
-                    // HACK:  asymtotiallcy approach zero  (maximum quality)
-                    // We'll fix this properly in a follow-up project.
-                    self.render_required = Some(0.5 * level);
-                } else {
-                    self.render_required = None;
-                }
             }
         }
-
-        self.redraw_required.load(Ordering::Acquire)
+        let redraw_required = self.redraw_required.load(Ordering::Acquire);
+        if redraw_required {
+            self.adaptive_quality_regulator.finish_rendering(time);
+        }
+        redraw_required
     }
 
     fn draw(&self, screen: &mut [u8]) {


### PR DESCRIPTION
Adds the render quality FSM, which encapsulates
the details required to adaptively switch between
interactive and background render modes, as well
as idle. For now, only uses a simple constant
render policy, but is general enough to support
arbitrary policies in the future.

Pulled out of https://github.com/MatthewPeterKelly/fractal-renderer/pull/141, to make both PRs a bit more scope-focused.