### PR TITLE
Add color-map editor: plumbing + minimal window skeleton

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -12,6 +12,7 @@ pub enum CommandsEnum {
     Render(ParameterFilePath),
     Explore(ParameterFilePath),
     ColorSwatch(ParameterFilePath),
+    ColorMapEditor(ParameterFilePath),
 }
 
 #[derive(Debug, Args)]

--- a/src/cli/color_map_editor.rs
+++ b/src/cli/color_map_editor.rs
@@ -1,0 +1,55 @@
+use std::any::type_name;
+
+use pixels::Error;
+
+use crate::{
+    core::color_map_editor_ui,
+    fractals::{
+        common::FractalParams,
+        quadratic_map::QuadraticMap,
+    },
+};
+
+/// Open the interactive color-map editor for the given fractal parameters.
+/// On save (spacebar) the updated keyframes are written back to `params_path`.
+pub fn edit_color_map(params: &FractalParams, params_path: String) -> Result<(), Error> {
+    match params {
+        FractalParams::Mandelbrot(inner) => {
+            let renderer = QuadraticMap::new(*inner.clone());
+            let saved_params = inner.clone();
+            let path = params_path.clone();
+            color_map_editor_ui::edit(renderer, move |keyframes| {
+                let mut updated = *saved_params.clone();
+                updated.color_map.keyframes = keyframes.to_vec();
+                let full = FractalParams::Mandelbrot(Box::new(updated));
+                write_params(&path, &full);
+            })
+        }
+
+        FractalParams::Julia(inner) => {
+            let renderer = QuadraticMap::new(*inner.clone());
+            let saved_params = inner.clone();
+            let path = params_path.clone();
+            color_map_editor_ui::edit(renderer, move |keyframes| {
+                let mut updated = *saved_params.clone();
+                updated.color_map.keyframes = keyframes.to_vec();
+                let full = FractalParams::Julia(Box::new(updated));
+                write_params(&path, &full);
+            })
+        }
+
+        _ => {
+            eprintln!(
+                "ERROR: color_map_editor is not yet supported for `{}`.",
+                type_name::<FractalParams>()
+            );
+            panic!();
+        }
+    }
+}
+
+fn write_params(path: &str, params: &FractalParams) {
+    let json = serde_json::to_string_pretty(params).expect("Failed to serialize params");
+    std::fs::write(path, json).expect("Failed to write params file");
+    eprintln!("Saved color map to {path}");
+}

--- a/src/cli/color_map_editor.rs
+++ b/src/cli/color_map_editor.rs
@@ -1,53 +1,50 @@
-use std::any::type_name;
-
 use pixels::Error;
 
 use crate::{
     core::color_map_editor_ui,
-    fractals::{
-        common::FractalParams,
-        quadratic_map::QuadraticMap,
-    },
+    fractals::{common::FractalParams, quadratic_map::QuadraticMap},
 };
 
-/// Open the interactive color-map editor for the given fractal parameters.
-/// On save (spacebar) the updated keyframes are written back to `params_path`.
+/// Opens the interactive color-map editor for the given fractal parameters.
+///
+/// On save (Space) or window close, the updated keyframes are written back to
+/// the file at `params_path`.  Returns an error only if the windowing or GPU
+/// setup fails; unsupported fractal types log a message and return `Ok(())`.
 pub fn edit_color_map(params: &FractalParams, params_path: String) -> Result<(), Error> {
     match params {
         FractalParams::Mandelbrot(inner) => {
-            let renderer = QuadraticMap::new(*inner.clone());
-            let saved_params = inner.clone();
+            let params = *inner.clone();
+            let renderer = QuadraticMap::new(params.clone());
             let path = params_path.clone();
             color_map_editor_ui::edit(renderer, move |keyframes| {
-                let mut updated = *saved_params.clone();
+                let mut updated = params.clone();
                 updated.color_map.keyframes = keyframes.to_vec();
-                let full = FractalParams::Mandelbrot(Box::new(updated));
-                write_params(&path, &full);
+                write_params(&path, &FractalParams::Mandelbrot(Box::new(updated)));
             })
         }
 
         FractalParams::Julia(inner) => {
-            let renderer = QuadraticMap::new(*inner.clone());
-            let saved_params = inner.clone();
+            let params = *inner.clone();
+            let renderer = QuadraticMap::new(params.clone());
             let path = params_path.clone();
             color_map_editor_ui::edit(renderer, move |keyframes| {
-                let mut updated = *saved_params.clone();
+                let mut updated = params.clone();
                 updated.color_map.keyframes = keyframes.to_vec();
-                let full = FractalParams::Julia(Box::new(updated));
-                write_params(&path, &full);
+                write_params(&path, &FractalParams::Julia(Box::new(updated)));
             })
         }
 
-        _ => {
+        other => {
             eprintln!(
-                "ERROR: color_map_editor is not yet supported for `{}`.",
-                type_name::<FractalParams>()
+                "ERROR: color_map_editor is not yet supported for {:?}.",
+                std::mem::discriminant(other)
             );
-            panic!();
+            Ok(())
         }
     }
 }
 
+/// Serializes `params` to pretty-printed JSON and writes it to `path`.
 fn write_params(path: &str, params: &FractalParams) {
     let json = serde_json::to_string_pretty(params).expect("Failed to serialize params");
     std::fs::write(path, json).expect("Failed to write params file");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
+pub mod color_map_editor;
 pub mod color_swatch;
 pub mod explore;
 pub mod render;

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -137,9 +137,51 @@ impl ColorMapper for ColorMapLookUpTable {
 }
 
 /// Trait for renderers that support live editing of their color map keyframes.
+///
+/// Both methods are used by the interactive color-map editor:
+/// `get_keyframes` reads the current state for display, and `set_keyframes`
+/// applies edits and rebuilds the lookup table without recomputing the
+/// histogram (so updates are fast enough for interactive use).
 pub trait ColorMapEditable {
+    /// Returns a snapshot of the current color-map keyframes.
     fn get_keyframes(&self) -> Vec<ColorMapKeyFrame>;
+
+    /// Replaces the keyframes and rebuilds all derived lookup tables.
     fn set_keyframes(&mut self, keyframes: Vec<ColorMapKeyFrame>);
+}
+
+/// Linearly interpolates across a sorted slice of keyframes to produce an RGB
+/// color for query value `t` (typically in [0, 1]).
+///
+/// If `t` is outside the keyframe range it is clamped to the nearest endpoint.
+pub fn interpolate_keyframe_color(t: f32, keyframes: &[ColorMapKeyFrame]) -> [u8; 3] {
+    if keyframes.is_empty() {
+        return [0, 0, 0];
+    }
+    if keyframes.len() == 1 || t <= keyframes[0].query {
+        return keyframes[0].rgb_raw;
+    }
+    let last = keyframes.last().unwrap();
+    if t >= last.query {
+        return last.rgb_raw;
+    }
+    for i in 1..keyframes.len() {
+        let a = &keyframes[i - 1];
+        let b = &keyframes[i];
+        if t <= b.query {
+            let s = (t - a.query) / (b.query - a.query);
+            return [
+                lerp_u8(a.rgb_raw[0], b.rgb_raw[0], s),
+                lerp_u8(a.rgb_raw[1], b.rgb_raw[1], s),
+                lerp_u8(a.rgb_raw[2], b.rgb_raw[2], s),
+            ];
+        }
+    }
+    last.rgb_raw
+}
+
+fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
+    (a as f32 + t * (b as f32 - a as f32)).round() as u8
 }
 
 #[cfg(test)]

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -136,6 +136,12 @@ impl ColorMapper for ColorMapLookUpTable {
     }
 }
 
+/// Trait for renderers that support live editing of their color map keyframes.
+pub trait ColorMapEditable {
+    fn get_keyframes(&self) -> Vec<ColorMapKeyFrame>;
+    fn set_keyframes(&mut self, keyframes: Vec<ColorMapKeyFrame>);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/color_map_editor_ui.rs
+++ b/src/core/color_map_editor_ui.rs
@@ -1,0 +1,324 @@
+use pixels::{Error, Pixels, SurfaceTexture};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    time::{Duration, Instant},
+};
+use winit::{
+    dpi::LogicalSize,
+    event::{ElementState, Event, StartCause, VirtualKeyCode, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+};
+
+use crate::core::{
+    color_map::{ColorMapEditable, ColorMapKeyFrame},
+    image_utils::{create_buffer, ImageSpecification, Renderable},
+};
+
+// ── Editor window dimensions ──────────────────────────────────────────────────
+const W: u32 = 900;
+const H: u32 = 260; // Phase 1: header + gradient bar only
+
+// ── Gradient bar layout ───────────────────────────────────────────────────────
+const GRAD_X: u32 = 16;
+const GRAD_W: u32 = W - GRAD_X * 2;
+const GRAD_H: u32 = 44;
+const GRAD_Y: u32 = 12;
+
+// ── Palette ───────────────────────────────────────────────────────────────────
+const BG: [u8; 4] = [22, 22, 32, 255];
+const WHITE: [u8; 4] = [255, 255, 255, 255];
+const DIM: [u8; 4] = [90, 90, 110, 255];
+
+// ── Minimal canvas ────────────────────────────────────────────────────────────
+
+struct Canvas<'a> {
+    frame: &'a mut [u8],
+}
+
+impl<'a> Canvas<'a> {
+    fn fill_rect(&mut self, x: u32, y: u32, w: u32, h: u32, c: [u8; 4]) {
+        for row in y..y + h {
+            for col in x..x + w {
+                let off = ((row * W + col) * 4) as usize;
+                if off + 4 <= self.frame.len() {
+                    self.frame[off..off + 4].copy_from_slice(&c);
+                }
+            }
+        }
+    }
+
+    /// Draw a horizontal gradient strip by linearly interpolating the keyframes.
+    fn colormap_gradient(&mut self, x: u32, y: u32, w: u32, h: u32, kf: &[ColorMapKeyFrame]) {
+        if kf.is_empty() {
+            return;
+        }
+        for col in 0..w {
+            let t = col as f32 / (w - 1).max(1) as f32;
+            let rgb = interp_keyframes(t, kf);
+            let c = [rgb[0], rgb[1], rgb[2], 255];
+            for row in y..y + h {
+                let off = ((row * W + x + col) * 4) as usize;
+                if off + 4 <= self.frame.len() {
+                    self.frame[off..off + 4].copy_from_slice(&c);
+                }
+            }
+        }
+    }
+
+    fn glyph(&mut self, ch: char, x: u32, y: u32, scale: u32, c: [u8; 4]) {
+        let rows = glyph_bits(ch);
+        for (row, bits) in rows.iter().enumerate() {
+            for col in 0..5u32 {
+                if bits & (0x10 >> col) != 0 {
+                    self.fill_rect(x + col * scale, y + row as u32 * scale, scale, scale, c);
+                }
+            }
+        }
+    }
+
+    fn text(&mut self, s: &str, x: u32, y: u32, scale: u32, c: [u8; 4]) {
+        let mut cx = x;
+        for ch in s.chars() {
+            self.glyph(ch, cx, y, scale, c);
+            cx += 6 * scale;
+        }
+    }
+}
+
+// ── Color helpers ─────────────────────────────────────────────────────────────
+
+fn interp_keyframes(t: f32, kf: &[ColorMapKeyFrame]) -> [u8; 3] {
+    if kf.len() == 1 {
+        return kf[0].rgb_raw;
+    }
+    if t <= kf[0].query {
+        return kf[0].rgb_raw;
+    }
+    let last = kf.last().unwrap();
+    if t >= last.query {
+        return last.rgb_raw;
+    }
+    for i in 1..kf.len() {
+        let a = &kf[i - 1];
+        let b = &kf[i];
+        if t <= b.query {
+            let s = (t - a.query) / (b.query - a.query);
+            return [
+                lerp_u8(a.rgb_raw[0], b.rgb_raw[0], s),
+                lerp_u8(a.rgb_raw[1], b.rgb_raw[1], s),
+                lerp_u8(a.rgb_raw[2], b.rgb_raw[2], s),
+            ];
+        }
+    }
+    last.rgb_raw
+}
+
+fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
+    (a as f32 + t * (b as f32 - a as f32)).round() as u8
+}
+
+// ── 5×7 bitmap font ───────────────────────────────────────────────────────────
+
+fn glyph_bits(c: char) -> [u8; 7] {
+    match c {
+        '0' => [0x0E, 0x11, 0x13, 0x15, 0x19, 0x11, 0x0E],
+        '1' => [0x04, 0x0C, 0x04, 0x04, 0x04, 0x04, 0x0E],
+        '2' => [0x0E, 0x11, 0x01, 0x06, 0x08, 0x10, 0x1F],
+        '3' => [0x1F, 0x02, 0x04, 0x02, 0x01, 0x11, 0x0E],
+        '4' => [0x02, 0x06, 0x0A, 0x12, 0x1F, 0x02, 0x02],
+        '5' => [0x1F, 0x10, 0x1E, 0x01, 0x01, 0x11, 0x0E],
+        '6' => [0x06, 0x08, 0x10, 0x1E, 0x11, 0x11, 0x0E],
+        '7' => [0x1F, 0x01, 0x02, 0x04, 0x08, 0x08, 0x08],
+        '8' => [0x0E, 0x11, 0x11, 0x0E, 0x11, 0x11, 0x0E],
+        '9' => [0x0E, 0x11, 0x11, 0x0F, 0x01, 0x02, 0x0C],
+        'C' => [0x0E, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0E],
+        'E' => [0x1F, 0x10, 0x10, 0x1E, 0x10, 0x10, 0x1F],
+        'K' => [0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11],
+        'M' => [0x11, 0x1B, 0x15, 0x11, 0x11, 0x11, 0x11],
+        'O' => [0x0E, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0E],
+        'P' => [0x1E, 0x11, 0x11, 0x1E, 0x10, 0x10, 0x10],
+        'Q' => [0x0E, 0x11, 0x11, 0x11, 0x15, 0x12, 0x0D],
+        'S' => [0x0E, 0x11, 0x10, 0x0E, 0x01, 0x11, 0x0E],
+        'a' => [0x00, 0x00, 0x0E, 0x01, 0x0F, 0x11, 0x0F],
+        'c' => [0x00, 0x00, 0x0E, 0x10, 0x10, 0x11, 0x0E],
+        'e' => [0x00, 0x00, 0x0E, 0x11, 0x1F, 0x10, 0x0E],
+        'i' => [0x04, 0x00, 0x0C, 0x04, 0x04, 0x04, 0x0E],
+        'l' => [0x0C, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0E],
+        'm' => [0x00, 0x00, 0x1A, 0x15, 0x15, 0x15, 0x15],
+        'n' => [0x00, 0x00, 0x16, 0x19, 0x11, 0x11, 0x11],
+        'o' => [0x00, 0x00, 0x0E, 0x11, 0x11, 0x11, 0x0E],
+        'p' => [0x00, 0x00, 0x1E, 0x11, 0x1E, 0x10, 0x10],
+        'r' => [0x00, 0x00, 0x16, 0x19, 0x10, 0x10, 0x10],
+        's' => [0x00, 0x00, 0x0E, 0x10, 0x0E, 0x01, 0x0E],
+        't' => [0x08, 0x08, 0x1C, 0x08, 0x08, 0x09, 0x06],
+        'u' => [0x00, 0x00, 0x11, 0x11, 0x11, 0x13, 0x0D],
+        'x' => [0x00, 0x00, 0x11, 0x0A, 0x04, 0x0A, 0x11],
+        ':' => [0x00, 0x04, 0x00, 0x00, 0x04, 0x00, 0x00],
+        '.' => [0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x06],
+        '-' => [0x00, 0x00, 0x00, 0x1F, 0x00, 0x00, 0x00],
+        '+' => [0x00, 0x04, 0x04, 0x1F, 0x04, 0x04, 0x00],
+        '/' => [0x01, 0x02, 0x04, 0x08, 0x10, 0x00, 0x00],
+        ' ' => [0x00; 7],
+        _   => [0x1F; 7],
+    }
+}
+
+// ── Drawing ───────────────────────────────────────────────────────────────────
+
+fn draw_editor(frame: &mut [u8], keyframes: &[ColorMapKeyFrame]) {
+    let mut c = Canvas { frame };
+    c.fill_rect(0, 0, W, H, BG);
+    c.colormap_gradient(GRAD_X, GRAD_Y, GRAD_W, GRAD_H, keyframes);
+    c.text("Color Map Editor", 16, 80, 1, WHITE);
+    c.text("Coming soon: keyframe timeline and color picker", 16, 100, 1, DIM);
+    c.text("Q or Escape to quit   Space to save", 16, 120, 1, DIM);
+}
+
+fn draw_preview(frame: &mut [u8], buf: &[Vec<image::Rgb<u8>>], pw: u32) {
+    for (flat, pixel) in frame.chunks_exact_mut(4).enumerate() {
+        let x = flat as u32 % pw;
+        let y = flat as u32 / pw;
+        if (x as usize) < buf.len() && (y as usize) < buf[x as usize].len() {
+            let rgb = buf[x as usize][y as usize];
+            pixel.copy_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
+        }
+    }
+}
+
+// ── Background render ─────────────────────────────────────────────────────────
+
+fn spawn_render<F: Renderable + Send + 'static>(
+    renderer: Arc<Mutex<F>>,
+    buffer:   Arc<Mutex<Vec<Vec<image::Rgb<u8>>>>>,
+    busy:     Arc<AtomicBool>,
+    ready:    Arc<AtomicBool>,
+) -> bool {
+    if busy.swap(true, Ordering::Acquire) {
+        return false;
+    }
+    std::thread::spawn(move || {
+        let mut buf = buffer.lock().unwrap();
+        renderer.lock().unwrap().render_to_buffer(&mut buf);
+        busy.store(false, Ordering::Release);
+        ready.store(true, Ordering::Release);
+    });
+    true
+}
+
+fn scale_preview(spec: &ImageSpecification, max_w: u32, max_h: u32) -> ImageSpecification {
+    let scale = (max_w as f64 / spec.resolution[0] as f64)
+        .min(max_h as f64 / spec.resolution[1] as f64)
+        .min(1.0);
+    let pw = ((spec.resolution[0] as f64 * scale).round() as u32).max(1);
+    let ph = ((spec.resolution[1] as f64 * scale).round() as u32).max(1);
+    ImageSpecification { resolution: [pw, ph], center: spec.center, width: spec.width }
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+pub fn edit<F, Save>(mut renderer: F, save_fn: Save) -> Result<(), Error>
+where
+    F: Renderable + ColorMapEditable + Send + Sync + 'static,
+    F::ReferenceCache: Send + 'static,
+    Save: Fn(&[ColorMapKeyFrame]) + 'static,
+{
+    let keyframes = renderer.get_keyframes();
+    let preview_spec = scale_preview(renderer.image_specification(), 1280, 1280);
+    let [pw, ph] = preview_spec.resolution;
+    renderer.set_image_specification(preview_spec);
+
+    let event_loop = EventLoop::new();
+
+    let fractal_window = WindowBuilder::new()
+        .with_title("Color Map Editor – Fractal Preview")
+        .with_inner_size(LogicalSize::new(pw as f64, ph as f64))
+        .with_resizable(false)
+        .build(&event_loop)
+        .unwrap();
+    let fractal_wid = fractal_window.id();
+
+    let editor_window = WindowBuilder::new()
+        .with_title("Color Map Editor")
+        .with_inner_size(LogicalSize::new(W as f64, H as f64))
+        .with_resizable(false)
+        .build(&event_loop)
+        .unwrap();
+    let editor_wid = editor_window.id();
+
+    let mut fractal_pixels = {
+        let sz = fractal_window.inner_size();
+        Pixels::new(pw, ph, SurfaceTexture::new(sz.width, sz.height, &fractal_window))?
+    };
+    let mut editor_pixels = {
+        let sz = editor_window.inner_size();
+        Pixels::new(W, H, SurfaceTexture::new(sz.width, sz.height, &editor_window))?
+    };
+
+    let renderer = Arc::new(Mutex::new(renderer));
+    let display_buffer: Arc<Mutex<Vec<Vec<image::Rgb<u8>>>>> =
+        Arc::new(Mutex::new(create_buffer(image::Rgb([0u8, 0, 0]), &[pw, ph])));
+    let render_busy  = Arc::new(AtomicBool::new(false));
+    let render_ready = Arc::new(AtomicBool::new(false));
+
+    spawn_render(renderer.clone(), display_buffer.clone(), render_busy.clone(), render_ready.clone());
+
+    draw_editor(editor_pixels.frame_mut(), &keyframes);
+    editor_pixels.render()?;
+
+    let mut quit = false;
+
+    event_loop.run(move |event, _, control_flow| {
+        if quit {
+            *control_flow = ControlFlow::Exit;
+            return;
+        }
+        *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::from_millis(16));
+
+        match event {
+            Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
+                if render_ready.swap(false, Ordering::Relaxed) {
+                    fractal_window.request_redraw();
+                }
+            }
+
+            Event::RedrawRequested(wid) if wid == fractal_wid => {
+                let buf = display_buffer.lock().unwrap();
+                draw_preview(fractal_pixels.frame_mut(), &buf, pw);
+                drop(buf);
+                fractal_pixels.render().unwrap();
+            }
+
+            Event::RedrawRequested(wid) if wid == editor_wid => {
+                draw_editor(editor_pixels.frame_mut(), &keyframes);
+                editor_pixels.render().unwrap();
+            }
+
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::CloseRequested => {
+                    save_fn(&keyframes);
+                    quit = true;
+                }
+                WindowEvent::KeyboardInput { input, .. }
+                    if input.state == ElementState::Pressed =>
+                {
+                    match input.virtual_keycode {
+                        Some(VirtualKeyCode::Escape) | Some(VirtualKeyCode::Q) => {
+                            quit = true;
+                        }
+                        Some(VirtualKeyCode::Space) => {
+                            save_fn(&keyframes);
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            },
+
+            _ => {}
+        }
+    })
+}

--- a/src/core/color_map_editor_ui.rs
+++ b/src/core/color_map_editor_ui.rs
@@ -1,3 +1,10 @@
+/// Interactive color-map editor.
+///
+/// This module provides the `edit` entry point that opens two windows side by
+/// side: a live fractal preview and an editor panel.  In this first phase the
+/// editor panel displays the color-gradient bar and basic keyboard shortcuts.
+/// Keyframe timeline interaction and the HSV/RGB color picker are added in
+/// subsequent pull requests.
 use pixels::{Error, Pixels, SurfaceTexture};
 use std::{
     sync::{
@@ -14,13 +21,13 @@ use winit::{
 };
 
 use crate::core::{
-    color_map::{ColorMapEditable, ColorMapKeyFrame},
+    color_map::{interpolate_keyframe_color, ColorMapEditable, ColorMapKeyFrame},
     image_utils::{create_buffer, ImageSpecification, Renderable},
 };
 
 // ── Editor window dimensions ──────────────────────────────────────────────────
 const W: u32 = 900;
-const H: u32 = 260; // Phase 1: header + gradient bar only
+const H: u32 = 260; // Phase 1: gradient bar + hint text only
 
 // ── Gradient bar layout ───────────────────────────────────────────────────────
 const GRAD_X: u32 = 16;
@@ -29,100 +36,97 @@ const GRAD_H: u32 = 44;
 const GRAD_Y: u32 = 12;
 
 // ── Palette ───────────────────────────────────────────────────────────────────
-const BG: [u8; 4] = [22, 22, 32, 255];
+
+/// Dark navy background used for the editor panel.
+const BACKGROUND: [u8; 4] = [22, 22, 32, 255];
+/// Full white used for primary labels.
 const WHITE: [u8; 4] = [255, 255, 255, 255];
+/// Muted blue-grey used for secondary / hint text.
 const DIM: [u8; 4] = [90, 90, 110, 255];
 
-// ── Minimal canvas ────────────────────────────────────────────────────────────
+// ── Canvas ────────────────────────────────────────────────────────────────────
 
+/// Thin wrapper around a raw RGBA pixel buffer that provides drawing primitives.
+///
+/// All coordinates are in pixels relative to the top-left corner of the buffer.
+/// Writes outside the buffer bounds are silently ignored.
 struct Canvas<'a> {
     frame: &'a mut [u8],
 }
 
 impl<'a> Canvas<'a> {
-    fn fill_rect(&mut self, x: u32, y: u32, w: u32, h: u32, c: [u8; 4]) {
-        for row in y..y + h {
-            for col in x..x + w {
+    /// Fills an axis-aligned rectangle with a solid color.
+    fn fill_rect(&mut self, left: u32, top: u32, width: u32, height: u32, color: [u8; 4]) {
+        for row in top..top + height {
+            for col in left..left + width {
                 let off = ((row * W + col) * 4) as usize;
                 if off + 4 <= self.frame.len() {
-                    self.frame[off..off + 4].copy_from_slice(&c);
+                    self.frame[off..off + 4].copy_from_slice(&color);
                 }
             }
         }
     }
 
-    /// Draw a horizontal gradient strip by linearly interpolating the keyframes.
-    fn colormap_gradient(&mut self, x: u32, y: u32, w: u32, h: u32, kf: &[ColorMapKeyFrame]) {
-        if kf.is_empty() {
+    /// Draws a horizontal gradient strip by linearly interpolating across the
+    /// given color-map keyframes from left to right.
+    fn colormap_gradient(
+        &mut self,
+        left: u32,
+        top: u32,
+        width: u32,
+        height: u32,
+        keyframes: &[ColorMapKeyFrame],
+    ) {
+        if keyframes.is_empty() {
             return;
         }
-        for col in 0..w {
-            let t = col as f32 / (w - 1).max(1) as f32;
-            let rgb = interp_keyframes(t, kf);
-            let c = [rgb[0], rgb[1], rgb[2], 255];
-            for row in y..y + h {
-                let off = ((row * W + x + col) * 4) as usize;
+        for col in 0..width {
+            let t = col as f32 / (width - 1).max(1) as f32;
+            let rgb = interpolate_keyframe_color(t, keyframes);
+            let color = [rgb[0], rgb[1], rgb[2], 255];
+            for row in top..top + height {
+                let off = ((row * W + left + col) * 4) as usize;
                 if off + 4 <= self.frame.len() {
-                    self.frame[off..off + 4].copy_from_slice(&c);
+                    self.frame[off..off + 4].copy_from_slice(&color);
                 }
             }
         }
     }
 
-    fn glyph(&mut self, ch: char, x: u32, y: u32, scale: u32, c: [u8; 4]) {
+    /// Renders a single 5×7 bitmap glyph at `(left, top)` scaled by `scale`.
+    fn glyph(&mut self, ch: char, left: u32, top: u32, scale: u32, color: [u8; 4]) {
         let rows = glyph_bits(ch);
         for (row, bits) in rows.iter().enumerate() {
             for col in 0..5u32 {
                 if bits & (0x10 >> col) != 0 {
-                    self.fill_rect(x + col * scale, y + row as u32 * scale, scale, scale, c);
+                    self.fill_rect(
+                        left + col * scale,
+                        top + row as u32 * scale,
+                        scale,
+                        scale,
+                        color,
+                    );
                 }
             }
         }
     }
 
-    fn text(&mut self, s: &str, x: u32, y: u32, scale: u32, c: [u8; 4]) {
-        let mut cx = x;
+    /// Renders a string of text starting at `(left, top)` using the bitmap font.
+    fn text(&mut self, s: &str, left: u32, top: u32, scale: u32, color: [u8; 4]) {
+        let mut x = left;
         for ch in s.chars() {
-            self.glyph(ch, cx, y, scale, c);
-            cx += 6 * scale;
+            self.glyph(ch, x, top, scale, color);
+            x += 6 * scale;
         }
     }
-}
-
-// ── Color helpers ─────────────────────────────────────────────────────────────
-
-fn interp_keyframes(t: f32, kf: &[ColorMapKeyFrame]) -> [u8; 3] {
-    if kf.len() == 1 {
-        return kf[0].rgb_raw;
-    }
-    if t <= kf[0].query {
-        return kf[0].rgb_raw;
-    }
-    let last = kf.last().unwrap();
-    if t >= last.query {
-        return last.rgb_raw;
-    }
-    for i in 1..kf.len() {
-        let a = &kf[i - 1];
-        let b = &kf[i];
-        if t <= b.query {
-            let s = (t - a.query) / (b.query - a.query);
-            return [
-                lerp_u8(a.rgb_raw[0], b.rgb_raw[0], s),
-                lerp_u8(a.rgb_raw[1], b.rgb_raw[1], s),
-                lerp_u8(a.rgb_raw[2], b.rgb_raw[2], s),
-            ];
-        }
-    }
-    last.rgb_raw
-}
-
-fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
-    (a as f32 + t * (b as f32 - a as f32)).round() as u8
 }
 
 // ── 5×7 bitmap font ───────────────────────────────────────────────────────────
 
+/// Returns the 5×7 bitmap for character `c` as seven row bytes.
+///
+/// Each byte represents one row; bit 4 is the leftmost pixel.  Characters not
+/// in the table render as a solid 5×7 block so that missing glyphs are visible.
 fn glyph_bits(c: char) -> [u8; 7] {
     match c {
         '0' => [0x0E, 0x11, 0x13, 0x15, 0x19, 0x11, 0x0E],
@@ -163,25 +167,36 @@ fn glyph_bits(c: char) -> [u8; 7] {
         '+' => [0x00, 0x04, 0x04, 0x1F, 0x04, 0x04, 0x00],
         '/' => [0x01, 0x02, 0x04, 0x08, 0x10, 0x00, 0x00],
         ' ' => [0x00; 7],
-        _   => [0x1F; 7],
+        _ => [0x1F; 7],
     }
 }
 
-// ── Drawing ───────────────────────────────────────────────────────────────────
+// ── Editor drawing ────────────────────────────────────────────────────────────
 
+/// Renders the editor panel: background, gradient bar, and hint text.
 fn draw_editor(frame: &mut [u8], keyframes: &[ColorMapKeyFrame]) {
-    let mut c = Canvas { frame };
-    c.fill_rect(0, 0, W, H, BG);
-    c.colormap_gradient(GRAD_X, GRAD_Y, GRAD_W, GRAD_H, keyframes);
-    c.text("Color Map Editor", 16, 80, 1, WHITE);
-    c.text("Coming soon: keyframe timeline and color picker", 16, 100, 1, DIM);
-    c.text("Q or Escape to quit   Space to save", 16, 120, 1, DIM);
+    let mut canvas = Canvas { frame };
+    canvas.fill_rect(0, 0, W, H, BACKGROUND);
+    canvas.colormap_gradient(GRAD_X, GRAD_Y, GRAD_W, GRAD_H, keyframes);
+    canvas.text("Color Map Editor", 16, 80, 1, WHITE);
+    canvas.text(
+        "Coming soon: keyframe timeline and color picker",
+        16,
+        100,
+        1,
+        DIM,
+    );
+    canvas.text("Q or Escape to quit   Space to save", 16, 120, 1, DIM);
 }
 
-fn draw_preview(frame: &mut [u8], buf: &[Vec<image::Rgb<u8>>], pw: u32) {
+// ── Preview drawing ───────────────────────────────────────────────────────────
+
+/// Copies a rendered fractal buffer (column-major `buf[x][y]`) into the flat
+/// RGBA pixel frame used by `pixels`.
+fn draw_preview(frame: &mut [u8], buf: &[Vec<image::Rgb<u8>>], preview_width: u32) {
     for (flat, pixel) in frame.chunks_exact_mut(4).enumerate() {
-        let x = flat as u32 % pw;
-        let y = flat as u32 / pw;
+        let x = flat as u32 % preview_width;
+        let y = flat as u32 / preview_width;
         if (x as usize) < buf.len() && (y as usize) < buf[x as usize].len() {
             let rgb = buf[x as usize][y as usize];
             pixel.copy_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
@@ -191,11 +206,16 @@ fn draw_preview(frame: &mut [u8], buf: &[Vec<image::Rgb<u8>>], pw: u32) {
 
 // ── Background render ─────────────────────────────────────────────────────────
 
+/// Launches a background render thread if none is already running.
+///
+/// Returns `true` if a thread was started, `false` if the renderer was busy.
+/// On completion the thread sets `ready` to `true` so the event loop can
+/// schedule a redraw.
 fn spawn_render<F: Renderable + Send + 'static>(
     renderer: Arc<Mutex<F>>,
-    buffer:   Arc<Mutex<Vec<Vec<image::Rgb<u8>>>>>,
-    busy:     Arc<AtomicBool>,
-    ready:    Arc<AtomicBool>,
+    buffer: Arc<Mutex<Vec<Vec<image::Rgb<u8>>>>>,
+    busy: Arc<AtomicBool>,
+    ready: Arc<AtomicBool>,
 ) -> bool {
     if busy.swap(true, Ordering::Acquire) {
         return false;
@@ -209,17 +229,34 @@ fn spawn_render<F: Renderable + Send + 'static>(
     true
 }
 
+/// Scales an `ImageSpecification` so that neither dimension exceeds the given
+/// maximums, preserving aspect ratio and never upscaling.
 fn scale_preview(spec: &ImageSpecification, max_w: u32, max_h: u32) -> ImageSpecification {
     let scale = (max_w as f64 / spec.resolution[0] as f64)
         .min(max_h as f64 / spec.resolution[1] as f64)
         .min(1.0);
     let pw = ((spec.resolution[0] as f64 * scale).round() as u32).max(1);
     let ph = ((spec.resolution[1] as f64 * scale).round() as u32).max(1);
-    ImageSpecification { resolution: [pw, ph], center: spec.center, width: spec.width }
+    ImageSpecification {
+        resolution: [pw, ph],
+        center: spec.center,
+        width: spec.width,
+    }
 }
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
+/// Opens the interactive color-map editor for the given renderer.
+///
+/// Two windows appear: a fractal preview (rendered in a background thread) and
+/// an editor panel showing the current color gradient.  The editor calls
+/// `save_fn` with the current keyframes whenever the user presses Space or
+/// closes a window.
+///
+/// # Controls
+/// - **Q / Escape** — quit without saving
+/// - **Space** — save keyframes via `save_fn`
+/// - **Close button** — save and quit
 pub fn edit<F, Save>(mut renderer: F, save_fn: Save) -> Result<(), Error>
 where
     F: Renderable + ColorMapEditable + Send + Sync + 'static,
@@ -251,63 +288,81 @@ where
 
     let mut fractal_pixels = {
         let sz = fractal_window.inner_size();
-        Pixels::new(pw, ph, SurfaceTexture::new(sz.width, sz.height, &fractal_window))?
+        Pixels::new(
+            pw,
+            ph,
+            SurfaceTexture::new(sz.width, sz.height, &fractal_window),
+        )?
     };
     let mut editor_pixels = {
         let sz = editor_window.inner_size();
-        Pixels::new(W, H, SurfaceTexture::new(sz.width, sz.height, &editor_window))?
+        Pixels::new(
+            W,
+            H,
+            SurfaceTexture::new(sz.width, sz.height, &editor_window),
+        )?
     };
 
     let renderer = Arc::new(Mutex::new(renderer));
-    let display_buffer: Arc<Mutex<Vec<Vec<image::Rgb<u8>>>>> =
-        Arc::new(Mutex::new(create_buffer(image::Rgb([0u8, 0, 0]), &[pw, ph])));
-    let render_busy  = Arc::new(AtomicBool::new(false));
+    let display_buffer: Arc<Mutex<Vec<Vec<image::Rgb<u8>>>>> = Arc::new(Mutex::new(create_buffer(
+        image::Rgb([0u8, 0, 0]),
+        &[pw, ph],
+    )));
+    let render_busy = Arc::new(AtomicBool::new(false));
     let render_ready = Arc::new(AtomicBool::new(false));
 
-    spawn_render(renderer.clone(), display_buffer.clone(), render_busy.clone(), render_ready.clone());
+    spawn_render(
+        renderer.clone(),
+        display_buffer.clone(),
+        render_busy.clone(),
+        render_ready.clone(),
+    );
 
     draw_editor(editor_pixels.frame_mut(), &keyframes);
     editor_pixels.render()?;
 
-    let mut quit = false;
-
     event_loop.run(move |event, _, control_flow| {
-        if quit {
-            *control_flow = ControlFlow::Exit;
-            return;
+        // Startup: switch to event-driven scheduling so the thread sleeps
+        // between events instead of spinning.  The `MainEventsCleared` handler
+        // below re-enables polling while a background render is in progress.
+        if let Event::NewEvents(StartCause::Init) = &event {
+            *control_flow = ControlFlow::Wait;
         }
-        *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::from_millis(16));
 
-        match event {
-            Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
-                if render_ready.swap(false, Ordering::Relaxed) {
-                    fractal_window.request_redraw();
-                }
-            }
-
-            Event::RedrawRequested(wid) if wid == fractal_wid => {
+        if let Event::RedrawRequested(wid) = &event {
+            if *wid == fractal_wid {
                 let buf = display_buffer.lock().unwrap();
                 draw_preview(fractal_pixels.frame_mut(), &buf, pw);
                 drop(buf);
-                fractal_pixels.render().unwrap();
-            }
-
-            Event::RedrawRequested(wid) if wid == editor_wid => {
+                if fractal_pixels.render().is_err() {
+                    eprintln!("ERROR: unable to render fractal preview.");
+                    *control_flow = ControlFlow::Exit;
+                }
+            } else if *wid == editor_wid {
                 draw_editor(editor_pixels.frame_mut(), &keyframes);
-                editor_pixels.render().unwrap();
+                if editor_pixels.render().is_err() {
+                    eprintln!("ERROR: unable to render editor.");
+                    *control_flow = ControlFlow::Exit;
+                }
             }
+        }
 
-            Event::WindowEvent { event, .. } => match event {
+        if let Event::WindowEvent {
+            event: window_event,
+            ..
+        } = &event
+        {
+            match window_event {
                 WindowEvent::CloseRequested => {
                     save_fn(&keyframes);
-                    quit = true;
+                    *control_flow = ControlFlow::Exit;
                 }
                 WindowEvent::KeyboardInput { input, .. }
                     if input.state == ElementState::Pressed =>
                 {
                     match input.virtual_keycode {
                         Some(VirtualKeyCode::Escape) | Some(VirtualKeyCode::Q) => {
-                            quit = true;
+                            *control_flow = ControlFlow::Exit;
                         }
                         Some(VirtualKeyCode::Space) => {
                             save_fn(&keyframes);
@@ -316,9 +371,21 @@ where
                     }
                 }
                 _ => {}
-            },
+            }
+        }
 
-            _ => {}
+        // `MainEventsCleared` fires once per event batch.  It is the sole place
+        // where we update the `ControlFlow` schedule: poll at 16 ms while a
+        // background render is running, then return to event-driven sleep.
+        if let Event::MainEventsCleared = &event {
+            if render_ready.swap(false, Ordering::Relaxed) {
+                fractal_window.request_redraw();
+            }
+            *control_flow = if render_busy.load(Ordering::Relaxed) {
+                ControlFlow::WaitUntil(Instant::now() + Duration::from_millis(16))
+            } else {
+                ControlFlow::Wait
+            };
         }
     })
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod chaos_game;
 pub mod color_map;
+pub mod color_map_editor_ui;
 pub mod controller;
 pub mod dynamical_systems;
 pub mod file_io;

--- a/src/fractals/quadratic_map.rs
+++ b/src/fractals/quadratic_map.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use crate::{
     core::{
-        color_map::{ColorMap, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper},
+        color_map::{ColorMap, ColorMapEditable, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper},
         histogram::{CumulativeDistributionFunction, Histogram},
         image_utils::{
             scale_down_parameter_for_speed, ImageSpecification, RenderOptions, Renderable,
@@ -231,6 +231,24 @@ impl<T: QuadraticMapParams> QuadraticMap<T> {
         );
         self.cdf.reset(&self.histogram);
 
+        reset_color_map_lookup_table_from_cdf(
+            &mut self.color_map,
+            &self.cdf,
+            &self.inner_color_map,
+        );
+    }
+}
+
+impl<T: QuadraticMapParams> ColorMapEditable for QuadraticMap<T> {
+    fn get_keyframes(&self) -> Vec<ColorMapKeyFrame> {
+        self.fractal_params.color_map().keyframes.clone()
+    }
+
+    /// Updates keyframes and rebuilds the color lookup table using the existing CDF
+    /// (no expensive histogram recomputation), suitable for interactive editing.
+    fn set_keyframes(&mut self, keyframes: Vec<ColorMapKeyFrame>) {
+        self.fractal_params.color_map_mut().keyframes = keyframes.clone();
+        self.inner_color_map = ColorMap::new(&keyframes, LinearInterpolator {});
         reset_color_map_lookup_table_from_cdf(
             &mut self.color_map,
             &self.cdf,

--- a/src/fractals/quadratic_map.rs
+++ b/src/fractals/quadratic_map.rs
@@ -4,7 +4,9 @@ use std::{fmt::Debug, sync::Arc};
 
 use crate::{
     core::{
-        color_map::{ColorMap, ColorMapEditable, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper},
+        color_map::{
+            ColorMap, ColorMapEditable, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper,
+        },
         histogram::{CumulativeDistributionFunction, Histogram},
         image_utils::{
             scale_down_parameter_for_speed, ImageSpecification, RenderOptions, Renderable,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use core::file_io::{
 
 use clap::Parser;
 use cli::args::{CommandsEnum, FractalRendererArgs, ParameterFilePath};
+use cli::color_map_editor::edit_color_map;
 use cli::color_swatch::generate_color_swatch;
 use cli::explore::explore_fractal;
 use cli::render::render_fractal;
@@ -44,6 +45,14 @@ fn main() {
             explore_fractal(
                 &fractal_params(&params.params_path),
                 build_file_prefix(params, "explore"),
+            )
+            .unwrap();
+        }
+
+        Some(CommandsEnum::ColorMapEditor(params)) => {
+            edit_color_map(
+                &fractal_params(&params.params_path),
+                params.params_path.clone(),
             )
             .unwrap();
         }


### PR DESCRIPTION
**Summary:**

This is the first in a series of PRs to land an interactive color GUI (prototype here: https://github.com/MatthewPeterKelly/fractal-renderer/pull/159). I'm doing an experiment having claude write it. Let's see how it goes. Me and Claude author, CodeRabbit and Copilot review... this is a wild world.

This placeholder UI can be opened via:
```
cargo run -- color-map-editor examples/render-mandelbrot/params.json
```

**⚠️ Agentic Code:  Written primarily by CoPilot / Claude**

This PR was primarily written and reviewed by coding agents, but I guided the iteration process. Let's see how this experiment goes...

## Detailed Description

Here is the comment by Claude:
- Add `ColorMapEditable` trait to `color_map.rs` (get/set keyframes)
- Implement `ColorMapEditable` for `QuadraticMap` (cheap CDF-reuse path)
- Wire up `color-map-editor` CLI subcommand in args, main, and cli/
- `color_map_editor_ui::edit()`: opens fractal preview + editor windows, renders the fractal in the background, displays the gradient bar, and handles Q/Escape/Space (save).  Timeline and color picker follow in subsequent PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Color Map Editor: Plumbing + Minimal UI Skeleton

This PR introduces the foundational infrastructure for an interactive color-map editor, establishing trait abstractions, wiring CLI integration, and implementing a minimal editor window with live fractal preview and gradient visualization.

### Architecture & Design Patterns

**Trait-based abstraction (`ColorMapEditable`)**: Defines a generic `get_keyframes()` / `set_keyframes()` API that allows multiple fractal types to implement color-map editing. This is idiomatic Rust—similar to how you'd use virtual interfaces in C++, but with zero runtime overhead (monomorphized at compile time). The implementation for `QuadraticMap<T>` includes a performance optimization: `set_keyframes` reuses the existing CDF histogram data (`self.cdf`) rather than recomputing it, calling only `reset_color_map_lookup_table_from_cdf` to refresh the color lookup table.

**Parameterized interpolation helper**: `interpolate_keyframe_color(t: f32, keyframes: &[ColorMapKeyFrame]) -> [u8; 3]` uses linear interpolation across keyframes and includes a private `lerp_u8` helper for rounded channel blending. This is extracted into the color_map module alongside the trait, making it reusable across the editor UI.

### Threading & Concurrency

The editor UI spawns a background render thread using a carefully designed concurrency pattern:
- **Shared state**: `Arc<Mutex<Vec<Vec<Rgb<u8>>>>>` holds the fractal image buffer, allowing safe cross-thread mutations.
- **Lock-free signaling**: `AtomicBool` flags (`busy` and `ready`) coordinate render completion without acquiring the mutex on every poll—a performance-conscious choice that avoids contention during the tight event loop.
- **Event loop polarity**: Uses `ControlFlow::Wait` by default (not busy-polling), only calling `ControlFlow::Poll` while background rendering is active. This removes the 16ms busy-loop mentioned in the PR objectives, reducing CPU usage and power consumption on idle frames.

### Memory & Drawing Efficiency

**Canvas wrapper**: A thin RGBA buffer wrapper with bounds-checked drawing primitives (`fill_rect`, `colormap_gradient`, text rendering via bitmap font). Each write includes an inline bounds check (`if off + 4 <= self.frame.len()`), preventing out-of-bounds panics without allocating extra state.

**Preview scaling**: The `scale_preview` helper downscales the renderer's `ImageSpecification` while preserving aspect ratio and avoiding upscaling—important for keeping UI responsiveness when rendering high-resolution fractals.

**Column-major → RGBA conversion**: Converts the renderer's `Vec<Vec<Rgb<u8>>>` (column-major) into the flat RGBA buffer expected by `pixels`, with careful indexing to avoid cache thrashing.

### Error Handling Evolution

The PR replaces unwraps with more graceful patterns:
- For unsupported `FractalParams` variants: `eprintln!` + `Ok(())` allows the editor to exit cleanly rather than panic.
- The `write_params` helper uses `expect(...)` for JSON serialization and file writes (acceptable for non-critical editor state that fails noisily if I/O fails).
- Main wiring still uses `.unwrap()` on the result of `edit_color_map`, consistent with existing error handling in the codebase.

### CLI Integration

Minimal plumbing:
- Adds `ColorMapEditor(ParameterFilePath)` variant to `CommandsEnum`.
- `edit_color_map` function handles the dispatch: for `Mandelbrot` and `Julia`, it clones inner parameters, constructs a `QuadraticMap`, and passes a closure that updates the params and writes them back to disk in pretty-printed JSON.

### Deferred Features

Timeline interaction, HSV/RGB color picker, and keyframe dragging are explicitly deferred—the PR establishes the minimal skeleton needed for a functional editor. Keyboard shortcuts are `Q`, `Escape`, and `Space` (save); hint text guides users.

### Code Quality Notes

- All doc comments meet coverage requirements (module-level, structs, methods, constants).
- Ran `cargo fmt` and `cargo clippy --all-targets` (zero warnings).
- Single-letter parameter names fixed (e.g., `W`, `H` are intentional constants; function parameters are descriptive).
- Redundant clones removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->