### PR TITLE
Add complete gui roadmap

### DIFF
--- a/docs/gui-unification-roadmap.md
+++ b/docs/gui-unification-roadmap.md
@@ -179,91 +179,194 @@ upgrades within the eframe family are unconstrained.
 
 ## 5. Data Model
 
-Two paired enums underpin the entire roadmap. The pairing is structural: each
-`UnifiedColorMap` variant has exactly one matching `CachedField` variant, and
-every fractal type fixes the variant pair it uses.
+Three concrete color-map shapes serve the three explorable fractal families.
+Their pairing with per-pixel field types is enforced **at compile time** via
+associated types on a `ColorMapKind` trait — there is no runtime tuple-match
+on the hot path, no `_ => panic!` arm, and no possibility of constructing a
+mismatched `(field, color_map)` pair from a `Renderable` impl. Validation
+happens once, at JSON deserialization; everything downstream is statically
+typed.
 
-### 5.1 `UnifiedColorMap`
+### 5.1 Per-variant concrete types
+
+Each color-map shape is its own struct:
 
 ```rust
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum UnifiedColorMap {
-    /// Two flat colors. Every pixel belongs to one of two classes; no
-    /// gradient information. Used by the driven-damped pendulum.
-    ForegroundBackground {
-        foreground: [u8; 3],
-        background: [u8; 3],
-    },
+pub struct ForegroundBackground {
+    pub foreground: [u8; 3],
+    pub background: [u8; 3],
+}
 
-    /// One flat background plus one gradient. The flat color is for points
-    /// that don't produce a graded output (e.g. inside the Mandelbrot set);
-    /// the gradient is sampled by a normalized scalar (smooth escape count).
-    /// Used by Mandelbrot and Julia.
-    BackgroundWithColorMap {
-        background: [u8; 3],
-        color_map: Vec<ColorMapKeyFrame>,
-    },
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BackgroundWithColorMap {
+    pub background: [u8; 3],
+    pub color_map: Vec<ColorMapKeyFrame>,
+}
 
-    /// One flat color plus one gradient per attractor. The flat covers
-    /// "did-not-converge" points; each attractor gets its own gradient
-    /// sampled by a smooth iteration count. Used by Newton's method.
-    MultiColorMap {
-        cyclic_attractor: [u8; 3],
-        color_maps: Vec<Vec<ColorMapKeyFrame>>,
-    },
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MultiColorMap {
+    pub cyclic_attractor: [u8; 3],
+    pub color_maps: Vec<Vec<ColorMapKeyFrame>>,
 }
 ```
 
-Variant names are descriptive (what the structure is), not fractal-named.
-Newton's `boundary_set_color_rgb` is intentionally absent: it is dead code in
-the renderer ([src/fractals/newtons_method.rs:416-428](../src/fractals/newtons_method.rs#L416-L428)
+Each per-pixel field shape is its own type alias:
+
+```rust
+pub type BinaryBasinField           = Vec<Vec<Option<i32>>>;
+pub type SmoothScalarField          = Vec<Vec<Option<f32>>>;
+pub type SmoothScalarWithIndexField = Vec<Vec<Option<(f32, usize)>>>;
+```
+
+Names are descriptive (what the structure *is*), not fractal-named.
+Newton's `boundary_set_color_rgb` is intentionally absent from `MultiColorMap`:
+it is dead code in the renderer ([src/fractals/newtons_method.rs:416-428](../src/fractals/newtons_method.rs#L416-L428)
 never reads it) and exists today only to define the "in-set" endpoint of the
 `GrayscaleSpec` shorthand, which Phase 1 drops.
 
-### 5.2 `CachedField`
+### 5.2 The `ColorMapKind` trait pairs them
 
 ```rust
-pub enum CachedField {
-    /// Per-pixel basin index. Used by the driven-damped pendulum.
-    BinaryBasin(Vec<Vec<Option<i32>>>),
+/// Pairs a color-map type with its matching per-pixel field type and
+/// defines how to colorize a field through the map.
+///
+/// Implementations are concrete structs; dispatch is monomorphized.
+/// There is no runtime variant matching on the colorize hot path.
+pub trait ColorMapKind: Clone + Send + Sync + 'static {
+    /// The per-pixel scalar this map consumes. Fixed at compile time
+    /// per concrete `ColorMapKind` impl.
+    type Field;
 
-    /// Per-pixel smooth escape count. Used by Mandelbrot and Julia.
-    SmoothScalar(Vec<Vec<Option<f32>>>),
+    /// Walk `field` and write colorized pixels into `out`. Pure pixel-level
+    /// work — no fractal computation, no allocation on the hot path.
+    fn colorize_into(&self, field: &Self::Field, out: &mut egui::ColorImage);
+}
 
-    /// Per-pixel (smooth iteration count, attractor index). Used by
-    /// Newton's method.
-    SmoothScalarWithIndex(Vec<Vec<Option<(f32, usize)>>>),
+impl ColorMapKind for ForegroundBackground {
+    type Field = BinaryBasinField;
+    fn colorize_into(&self, field: &Self::Field, out: &mut egui::ColorImage) {
+        // Some(0) → foreground; Some(_) or None → background.
+    }
+}
+
+impl ColorMapKind for BackgroundWithColorMap {
+    type Field = SmoothScalarField;
+    fn colorize_into(&self, field: &Self::Field, out: &mut egui::ColorImage) {
+        // None → background; Some(f) → color_map.lookup(f).
+    }
+}
+
+impl ColorMapKind for MultiColorMap {
+    type Field = SmoothScalarWithIndexField;
+    fn colorize_into(&self, field: &Self::Field, out: &mut egui::ColorImage) {
+        // None → cyclic_attractor; Some((f, k)) → color_maps[k].lookup(f).
+    }
 }
 ```
 
-### 5.3 Pairing table
+`Renderable` then carries the pairing as associated types:
 
-| `UnifiedColorMap` variant | `CachedField` variant      | Fractal                  | Colorization rule                                                                  |
-| ------------------------- | -------------------------- | ------------------------ | ---------------------------------------------------------------------------------- |
-| `ForegroundBackground`    | `BinaryBasin`              | DDP                      | `Some(0)` → `foreground`; `Some(_)` or `None` → `background`                       |
-| `BackgroundWithColorMap`  | `SmoothScalar`             | Mandelbrot, Julia        | `None` → `background`; `Some(f)` → `color_map.lookup(f)`                           |
-| `MultiColorMap`           | `SmoothScalarWithIndex`    | Newton's method          | `None` → `cyclic_attractor`; `Some((f, k))` → `color_maps[k].lookup(f)`            |
+```rust
+pub trait Renderable: Sync + Send + SpeedOptimizer {
+    type Params: Serialize + Debug;
+    type ColorMap: ColorMapKind;
 
-The free function `colorize(field: &CachedField, map: &UnifiedColorMap) ->
-ColorImage` matches on the `(field, map)` tuple. Mismatched variants
-(`BinaryBasin` × `BackgroundWithColorMap`, etc.) panic with a clear "wiring
-bug" message — by construction this case never arises from valid params files,
-since each fractal's `Renderable` impl returns the correct `CachedField`
-variant and embeds the matching `UnifiedColorMap` variant.
+    fn compute_field(&self) -> <Self::ColorMap as ColorMapKind>::Field;
+    fn color_map(&self) -> &Self::ColorMap;
+    fn color_map_mut(&mut self) -> &mut Self::ColorMap;  // added in Phase 6
 
-### 5.4 Why the typed enum (vs a `Vec<LabeledGradient>` flat list)
+    // Default render impl — fully monomorphized, statically dispatched:
+    fn render_to_color_image(&self, out: &mut egui::ColorImage) {
+        let field = self.compute_field();
+        self.color_map().colorize_into(&field, out);
+    }
+    // ... other existing methods unchanged.
+}
+```
 
-Considered earlier and rejected:
+The hot path is generic over `F: Renderable`. Dispatch happens once, at the
+top of [src/cli/explore.rs](../src/cli/explore.rs) where `match
+fractal_params { … }` selects the concrete `F` to instantiate. From there
+inward, every call site is monomorphized: `compute_field` returns the
+concrete `Field` type, `color_map()` returns the concrete `ColorMap` type,
+`colorize_into` is a static method call on the concrete impl. The compiler
+enforces the pairing.
 
-- A flat `Vec<LabeledGradient>` would require positional conventions
-  ("entry 0 is always background, entries 1..N are gradients") that are easy
-  to drift between editor and renderer, and the editor would still need a
-  "is this a flat color or a gradient?" discriminator per entry, plus a
-  per-fractal label lookup table.
-- The typed enum gives compiler-enforced exhaustiveness, role-as-data
-  (no positional contract), no round-trip conversion at the editor/renderer
-  boundary, and small editor dispatch (one match arm per variant, ~25 LoC,
-  with shared `show_swatch` / `show_gradient_editor` widget helpers).
+### 5.3 Per-fractal pairings
+
+| Concrete `ColorMap` type   | Concrete `Field` type            | Fractal                  | Colorization rule                                                       |
+| -------------------------- | -------------------------------- | ------------------------ | ----------------------------------------------------------------------- |
+| `ForegroundBackground`     | `BinaryBasinField`               | DDP                      | `Some(0)` → `foreground`; `Some(_)` or `None` → `background`            |
+| `BackgroundWithColorMap`   | `SmoothScalarField`              | Mandelbrot, Julia        | `None` → `background`; `Some(f)` → `color_map.lookup(f)`                |
+| `MultiColorMap`            | `SmoothScalarWithIndexField`     | Newton's method          | `None` → `cyclic_attractor`; `Some((f, k))` → `color_maps[k].lookup(f)` |
+
+Each fractal's params struct embeds its concrete `ColorMap` type directly
+(e.g. `MandelbrotParams` carries `pub color: BackgroundWithColorMap`).
+serde-derived `Deserialize` rejects the wrong shape at JSON load time with
+a structured error — there is no in-memory invariant left to violate.
+
+### 5.4 `UnifiedColorMap` and `CachedField` as boundary types only
+
+For places that genuinely need to handle all three shapes uniformly — e.g. a
+diagnostic dump that walks any fractal's color map, or a future cross-fractal
+inspection tool — the three concrete types share an upcast enum:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum UnifiedColorMap {
+    ForegroundBackground(ForegroundBackground),
+    BackgroundWithColorMap(BackgroundWithColorMap),
+    MultiColorMap(MultiColorMap),
+}
+
+impl From<ForegroundBackground> for UnifiedColorMap { /* … */ }
+impl From<BackgroundWithColorMap> for UnifiedColorMap { /* … */ }
+impl From<MultiColorMap> for UnifiedColorMap { /* … */ }
+
+#[derive(Debug)]
+pub enum CachedField {
+    BinaryBasin(BinaryBasinField),
+    SmoothScalar(SmoothScalarField),
+    SmoothScalarWithIndex(SmoothScalarWithIndexField),
+}
+```
+
+These enums are **not** used on the colorize hot path, **not** used by the
+editor (which is generic over the concrete `ColorMap` type — see §6 Phase 4),
+and **not** used as the JSON wire format (each fractal's params embeds the
+concrete struct directly). They exist only as an opt-in upcast for code that
+truly needs polymorphism over color-map shape. If no such caller materializes,
+they can be dropped in a later cleanup.
+
+### 5.5 Why static typing all the way down
+
+The earlier-considered design used a single `UnifiedColorMap` enum + a single
+`CachedField` enum + a free `colorize(field, map) -> ColorImage` function
+that matched on the tuple. That approach had a runtime invariant — "the
+caller passed compatible variants" — backed only by a `_ => panic!` arm. The
+hot path paid the cost of a tuple match per render, and a bug in any
+`Renderable` impl would surface as a runtime panic instead of a compile
+error.
+
+The trait-based design described above:
+
+- **Eliminates the panic path.** Mismatched pairings are unrepresentable.
+- **Eliminates the tuple match.** The compiler monomorphizes `colorize_into`
+  to the concrete impl per fractal type.
+- **Pushes all validation to JSON deserialization.** A malformed params file
+  fails to parse with a structured error; there is no later place where the
+  invariant can be violated.
+- **Keeps the editor static too** (Phase 4): the editor widget is generic
+  over the concrete `ColorMap` type, with per-variant `show_editor`
+  implementations colocated with each variant's data.
+
+A flat `Vec<LabeledGradient>` representation was also considered and
+rejected: it would require positional conventions ("entry 0 is always
+background, entries 1..N are gradients") that drift between editor and
+renderer, and would still need a "flat vs gradient" discriminator per entry
+plus a per-fractal label lookup. The trait-based design has none of these
+problems.
 
 ---
 
@@ -271,23 +374,28 @@ Considered earlier and rejected:
 
 ### Phase 1 — Color-map data unification
 
-**Goal:** every fractal type embeds `UnifiedColorMap` directly in its params
-struct. JSON schema migrates accordingly. No GUI work.
+**Goal:** introduce the per-variant concrete color-map structs and embed each
+fractal type's matching struct directly in its params. JSON schema migrates
+accordingly. No GUI work, no trait changes (Phase 2 handles trait wiring).
 
 **Files touched:**
 
-- [src/core/color_map.rs](../src/core/color_map.rs) — define `UnifiedColorMap`.
+- [src/core/color_map.rs](../src/core/color_map.rs) — define
+  `ForegroundBackground`, `BackgroundWithColorMap`, `MultiColorMap` concrete
+  structs (per §5.1). Optionally define the `UnifiedColorMap` boundary-only
+  enum and `From` impls (per §5.4); skip if no caller materializes for them
+  in this phase.
 - [src/fractals/quadratic_map.rs](../src/fractals/quadratic_map.rs) — replace
-  `ColorMapParams.keyframes` and `background_color_rgb` with `color:
-  UnifiedColorMap` (constrained to `BackgroundWithColorMap`). The other
-  `ColorMapParams` fields (`lookup_table_count`, `histogram_bin_count`,
-  `histogram_sample_count`) are not color data and stay on `QuadraticMapParams`
-  directly (or move into a sibling struct — implementer's choice).
+  `ColorMapParams.keyframes` and `background_color_rgb` with `pub color:
+  BackgroundWithColorMap`. The other `ColorMapParams` fields
+  (`lookup_table_count`, `histogram_bin_count`, `histogram_sample_count`) are
+  not color data and stay on `QuadraticMapParams` directly (or move into a
+  sibling struct — implementer's choice).
 - [src/fractals/mandelbrot.rs](../src/fractals/mandelbrot.rs),
   [src/fractals/julia.rs](../src/fractals/julia.rs) — automatic via the
   `QuadraticMapParams` trait change.
 - [src/fractals/driven_damped_pendulum.rs](../src/fractals/driven_damped_pendulum.rs)
-  — add `color: UnifiedColorMap` field with
+  — add `pub color: ForegroundBackground` field with
   `#[serde(default = "ddp_default_color")]`. Default is
   `ForegroundBackground { foreground: [255,255,255], background: [0,0,0] }`,
   matching the previously hard-coded values. Replace the literal
@@ -295,12 +403,11 @@ struct. JSON schema migrates accordingly. No GUI work.
   field.
 - [src/fractals/newtons_method.rs](../src/fractals/newtons_method.rs) —
   replace `boundary_set_color_rgb`, `cyclic_attractor_color_rgb`, and
-  `color_map_spec` in `CommonParams` with a single `color: UnifiedColorMap`
-  field (constrained to `MultiColorMap`). **Drop `GrayscaleSpec` and
-  `GrayscaleKeyframeSpec` entirely**, including the `to_color_map_vec`
-  expansion logic. The `ColorMapSpec` enum can be removed; if its other
-  variant `FullColorSpec` is kept around as an alias type, that's fine, but
-  the simpler path is to delete it too.
+  `color_map_spec` in `CommonParams` with a single `pub color: MultiColorMap`
+  field. **Drop `GrayscaleSpec` and `GrayscaleKeyframeSpec` entirely**,
+  including the `to_color_map_vec` expansion logic. The `ColorMapSpec` enum
+  is removed (its `FullColorSpec` variant becomes redundant once
+  `MultiColorMap` is the embedded type).
 - Every JSON file under [examples/](../examples/), [benches/](../benches/),
   and [tests/param_files/](../tests/param_files/) that references a fractal
   whose schema changed. The
@@ -315,56 +422,66 @@ struct. JSON schema migrates accordingly. No GUI work.
 must remain unchanged (color computation is logically identical, only the
 schema moved).
 
-**Variant slack:** each fractal's params struct holds `color: UnifiedColorMap`
-typed as the full enum, not a refinement to one variant. Construction-time
-validation (or a `match` in the renderer that panics on the wrong variant)
-catches misuse. The slack is acceptable in exchange for not needing per-fractal
-narrow types.
+**Static-typing invariant:** each fractal embeds its concrete color-map
+struct directly. There is no enum wrapper at the params level and no runtime
+"is this the right variant" check. Wrong-shape JSON fails serde
+deserialization with a structured error before any fractal object is
+constructed; once construction succeeds, the type is permanently fixed.
 
 ### Phase 2 — Compute / color split
 
 **Goal:** factor `Renderable` so the per-pixel scalar computation is separated
-from colorization. No observable behavior change; pixel hashes unchanged.
+from colorization, with the pairing enforced by associated types (per §5).
+No observable behavior change; pixel hashes unchanged.
 
 **Files touched:**
 
+- [src/core/color_map.rs](../src/core/color_map.rs) — define the
+  `ColorMapKind` trait and implement it for each of the three concrete
+  color-map structs. Each impl provides its own `colorize_into` — no free
+  function, no tuple match.
 - [src/core/image_utils.rs](../src/core/image_utils.rs) — extend `Renderable`
-  trait. Add `CachedField` enum. Add `colorize(field, map)` and
-  `colorize_into(field, map, &mut buffer)` free functions.
+  with associated types `ColorMap: ColorMapKind` and methods
+  `compute_field`, `color_map`. Provide a default `render_to_color_image`
+  that chains the two.
 - [src/fractals/quadratic_map.rs](../src/fractals/quadratic_map.rs),
   [src/fractals/driven_damped_pendulum.rs](../src/fractals/driven_damped_pendulum.rs),
   [src/fractals/newtons_method.rs](../src/fractals/newtons_method.rs) —
-  implement `compute_field()`; default `render_to_buffer` to
-  `compute_field()` then `colorize_into(...)`. Where today's renderer does
-  histogram/CDF setup that depends on the field but not the keyframes
-  (e.g. [src/fractals/quadratic_map.rs:225](../src/fractals/quadratic_map.rs#L225)),
-  that work happens at the `compute_field` boundary so the per-fractal
-  prep cost is paid once per compute, not once per re-colorize.
+  implement the new associated types and methods. Each fractal binds
+  `type ColorMap` to the concrete struct it embedded in Phase 1
+  (`BackgroundWithColorMap`, `ForegroundBackground`, `MultiColorMap`).
+  Where today's renderer does histogram/CDF setup that depends on the field
+  but not the keyframes (e.g. [src/fractals/quadratic_map.rs:225](../src/fractals/quadratic_map.rs#L225)),
+  that work happens at the `compute_field` boundary so the per-fractal prep
+  cost is paid once per compute, not once per re-colorize.
 
 **Sketch:**
 
 ```rust
 pub trait Renderable: Sync + Send + SpeedOptimizer {
     type Params: Serialize + Debug;
+    type ColorMap: ColorMapKind;
 
-    fn compute_field(&self) -> CachedField;
-    fn color_map(&self) -> &UnifiedColorMap;
+    fn compute_field(&self) -> <Self::ColorMap as ColorMapKind>::Field;
+    fn color_map(&self) -> &Self::ColorMap;
     // color_map_mut added in Phase 6, not here.
 
     // Existing methods unchanged: image_specification, render_options,
     // set_image_specification, write_diagnostics, params, render_point.
 
-    // Default impl rewires through compute + colorize:
-    fn render_to_buffer(&self, buffer: &mut Vec<Vec<Rgb<u8>>>) {
+    // Default impl — fully monomorphized, statically dispatched:
+    fn render_to_color_image(&self, out: &mut egui::ColorImage) {
         let field = self.compute_field();
-        colorize_into(&field, self.color_map(), buffer);
+        self.color_map().colorize_into(&field, out);
     }
 }
 ```
 
-**Unit tests added:** `colorize` correctness for each `(CachedField,
-UnifiedColorMap)` pairing, including edge cases (empty `color_maps` for
-`MultiColorMap`, all-`None` field for each variant, single-keyframe gradients).
+**Unit tests added** (§10.1): `colorize_into` correctness per
+`ColorMapKind` impl, including all-`None` fields, single-keyframe gradients,
+and (for `MultiColorMap`) coverage of every entry in `color_maps`. Tests are
+written against the concrete struct types directly — no tuple-match logic to
+exercise, no panic paths to defend.
 
 **Verification:** pixel-hash regression tests must pass unchanged. `cargo
 bench --no-run` to confirm benchmarks still compile; `cargo bench` on the
@@ -405,19 +522,31 @@ on every panel — matches current explore mode and avoids border artifacts
 ### Phase 4 — Color editor panel
 
 **Goal:** add the right-side color editor panel to `FractalApp`. Editor
-displays the loaded `UnifiedColorMap` and allows local mutation of a
-**cached copy**. The fractal preview is not affected by edits — that's
-Phase 6.
+displays the loaded color map and allows local mutation of a **cached
+copy**. The fractal preview is not affected by edits — that's Phase 6.
 
 **Files touched:**
 
-- `src/core/interactive/editor.rs` — new; per-variant editor widgets,
-  shared helpers (`show_swatch`, `show_gradient_editor`), tab strip for
-  `MultiColorMap`.
-- `src/core/interactive/app.rs` — extend layout: `SidePanel::right` for the
-  editor, `CentralPanel` for the preview. `FractalApp` gains
-  `editor_color_map: UnifiedColorMap` and editor selection state (selected
-  keyframe index, active Newton tab).
+- `src/core/interactive/editor.rs` — new. Defines a `ColorMapEditor`
+  trait (extends `ColorMapKind`) with per-variant `show_editor`
+  implementations on each concrete struct. The trait method takes
+  `&mut self` plus `&mut egui::Ui` and returns whether anything changed:
+  ```rust
+  pub trait ColorMapEditor: ColorMapKind {
+      fn show_editor(&mut self, ui: &mut egui::Ui, state: &mut EditorState) -> bool;
+  }
+  ```
+  Shared widget helpers (`show_swatch`, `show_gradient_segment`, fraction
+  renormalization) live as free functions used by all three impls.
+  `MultiColorMap`'s impl renders the tab strip and routes the active
+  tab's gradient through the same shared helpers.
+- `src/core/interactive/app.rs` — extend layout: `SidePanel::right` for
+  the editor, `CentralPanel` for the preview. `FractalApp<F>` gains
+  `editor_color_map: F::ColorMap` (a clone of the renderer's typed color
+  map — concrete, not enum) and a small `EditorState` for selection
+  (selected keyframe index, active Newton tab). Calls
+  `self.editor_color_map.show_editor(ui, &mut self.editor_state)` in the
+  panel — fully monomorphized, zero runtime variant matching.
 
 **Layout:**
 
@@ -446,11 +575,11 @@ Phase 6.
 
 Detailed widget spec is in §7.
 
-**Local-cache lifecycle:** `editor_color_map` is initialized at startup as a
-clone of the renderer's `UnifiedColorMap`. All editor widgets mutate only this
-cache. The renderer continues to use its own (immutable, in this phase) map.
-Edits do not survive window close (no save-back to disk; Space-as-save in
-Phase 5 captures the cache to a fresh timestamped JSON).
+**Local-cache lifecycle:** `editor_color_map: F::ColorMap` is initialized at
+startup as a clone of `renderer.color_map()`. All editor widgets mutate only
+this cache. The renderer continues to use its own (immutable, in this phase)
+color map. Edits do not survive window close (no save-back to disk;
+Space-as-save in Phase 5 captures the cache to a fresh timestamped JSON).
 
 ### Phase 5 — CLI + cleanup + extended Space-as-save
 
@@ -498,33 +627,37 @@ the exact GUI state including colors.
 **Goal:** color edits in the editor panel cause the fractal preview to
 re-colorize live (target: <1 frame latency at 1080p).
 
-**Approach:** the `CachedField` produced by `compute_field` does not depend
-on the color map, so we cache it after each compute and re-colorize from it
-on every color edit. Re-colorize is pure pixel-level work (no fractal math)
-and is fast enough to run on demand.
+**Approach:** `compute_field` produces an `<F::ColorMap as ColorMapKind>::Field`
+that does not depend on the color map, so we cache it after each compute and
+re-colorize from it on every color edit. Re-colorize is pure pixel-level work
+(no fractal math) and is fast enough to run on demand.
 
 **Files touched:**
 
 - [src/core/image_utils.rs](../src/core/image_utils.rs) — add
-  `color_map_mut(&mut self) -> &mut UnifiedColorMap` to `Renderable`.
+  `color_map_mut(&mut self) -> &mut Self::ColorMap` to `Renderable`.
 - [src/core/render_window.rs](../src/core/render_window.rs) — extend
-  `PixelGrid` to:
-  - Cache the most recent `CachedField` after each compute (alongside the
-    existing `display_buffer`).
+  `PixelGrid<F>` to:
+  - Cache the most recent field as `Arc<Mutex<Option<<F::ColorMap as ColorMapKind>::Field>>>`
+    after each compute (alongside the existing `display_buffer`). The type
+    is fixed by `F` at construction; no enum unwrap on the hot path.
   - Add an `Arc<AtomicBool>` `color_dirty` flag.
   - In `update()`, if `color_dirty` is set and no compute is in flight,
     spawn a background task that just re-colorizes the cached field into
-    `display_buffer` (skipping `compute_field`).
+    `display_buffer` via `renderer.color_map().colorize_into(...)`
+    (skipping `compute_field`).
 - `src/core/interactive/app.rs` — wire editor edits: when the editor mutates
   a keyframe / fraction / flat color, write the change into
   `renderer.color_map_mut()`, set `color_dirty`, call `ctx.request_repaint()`.
-- `src/core/interactive/editor.rs` — return an "edited" boolean from each
-  editor function so the app knows when to set `color_dirty`.
+- `src/core/interactive/editor.rs` — `show_editor` already returns whether
+  anything changed (per Phase 4); the app uses that boolean to gate
+  `color_dirty`.
 
-**Editor cache transition:** the separate `editor_color_map` from Phase 4
-becomes redundant. The editor now mutates `renderer.color_map_mut()` directly.
-The app retains only editor *selection* state (selected keyframe index, active
-Newton tab) — the data lives on the renderer.
+**Editor cache transition:** the separate `editor_color_map: F::ColorMap` from
+Phase 4 becomes redundant. The editor now mutates `renderer.color_map_mut()`
+directly (still typed as `&mut F::ColorMap`, statically dispatched). The app
+retains only editor *selection* state (selected keyframe index, active Newton
+tab) — the data lives on the renderer.
 
 **Adaptive quality regulator interaction:** color edits trigger only
 re-colorize, not re-compute, so the regulator's compute-quality scaling is not
@@ -664,16 +797,17 @@ Idle ──Space pressed──► Saving ──save complete──► Idle
    `speed_optimization_level = 0.0`. The field will be computed at full
    user-specified quality, not whatever degraded state interactive use had
    pushed it to.
-3. **Sync color map.** Push the editor's current `UnifiedColorMap` (which in
-   Phase 6 *is* the renderer's map; in Phase 5 was a separate cache) into the
-   renderer's params for serialization.
+3. **Sync color map.** Push the editor's current color map (which in Phase 6
+   *is* `renderer.color_map_mut()`; in Phase 5 was a separate
+   `editor_color_map: F::ColorMap` cache) into the renderer's params for
+   serialization.
 4. **Render to GUI.** Background thread runs `compute_field` (full quality)
-   followed by `colorize` (with synced map) and swaps the result into the
-   preview texture. The save flow blocks (overlay still up) until the render
-   is complete.
+   followed by `color_map().colorize_into(...)` and swaps the result into
+   the preview texture. The save flow blocks (overlay still up) until the
+   render is complete.
 5. **Save params to disk.** Serialize the now-synced `FractalParams`
-   (including embedded `UnifiedColorMap` and the current view-control's
-   `image_specification`) to `<prefix>_<datetime>.json`. The
+   (including the embedded concrete color-map struct and the current
+   view-control's `image_specification`) to `<prefix>_<datetime>.json`. The
    filename pattern matches today's
    [src/core/render_window.rs:255-261](../src/core/render_window.rs#L255-L261).
 6. **Save image to disk.** Write the just-rendered buffer to
@@ -728,12 +862,23 @@ regulator self-tunes from observed compute time, so the choice doesn't change
 the architecture, only the UX feel of "how aggressively does quality bounce
 back up after the user stops dragging a slider."
 
-### 9.4 BarnsleyFern and Serpinsky
+### 9.4 Static-dispatch invariant
+
+The renderer hot path is fully monomorphized over `F: Renderable`. Every
+`compute_field` call returns the concrete `<F::ColorMap as ColorMapKind>::Field`
+type known at compile time; every `colorize_into` call dispatches to the
+concrete `ColorMapKind` impl for that fractal. There is no enum match, no
+`dyn Renderable`, no runtime variant check on the colorize hot path. The
+only runtime dispatch in the system is the single
+`match fractal_params { … }` in [src/cli/explore.rs](../src/cli/explore.rs)
+that selects which concrete `F` to instantiate at startup.
+
+### 9.5 BarnsleyFern and Serpinsky
 
 Continue to panic in `cli::explore::explore_fractal` with "Parameter type does
 not yet implement RenderWindow." Out of scope for this entire roadmap. Their
-params structs are not migrated to `UnifiedColorMap` (Phase 1) and they do not
-implement `compute_field` (Phase 2).
+params structs are not migrated (Phase 1) and they do not implement the
+`Renderable` associated types `ColorMap` / `Field` (Phase 2).
 
 ---
 
@@ -745,13 +890,15 @@ but may be added later if a particular bug class becomes recurring.
 
 ### 10.1 What to unit-test (mandatory)
 
-- `colorize(field, map)` correctness for every `(CachedField, UnifiedColorMap)`
-  pairing, including:
-  - All-`None` field for each variant.
+- `ColorMapKind::colorize_into` correctness, with one test module per
+  concrete impl (`ForegroundBackground`, `BackgroundWithColorMap`,
+  `MultiColorMap`):
+  - All-`None` field.
   - Single-keyframe gradients.
   - Boundary keyframe values (0.0 and 1.0).
-  - `MultiColorMap` with empty `color_maps` (must error or panic with a
-    clear message — not silently produce garbage).
+  - `MultiColorMap` with empty `color_maps`: rejected at deserialization
+    or at construction with a structured error; not reachable on the
+    colorize hot path. (No runtime panic in `colorize_into`.)
 - Fraction renormalization: edit one fraction in a 4-keyframe gradient,
   assert the others scale proportionally and the resulting positions match
   expectations. Edge cases: edit to ε, edit to 1−ε, edit to 0 (clamped),
@@ -760,13 +907,18 @@ but may be added later if a particular bug class becomes recurring.
   expected midpoint position and the expected interpolated color.
 - Keyframe deletion: removing the second keyframe in a 3-keyframe gradient
   preserves positions 0.0 and 1.0 of the anchors and removes the middle one.
-- `UnifiedColorMap` serde round-trips for every variant.
-- `CachedField` construction for each fractal: a small synthetic
-  `ImageSpecification` produces the expected variant with the expected size
-  and the expected entries at known points.
+- serde round-trips for each concrete color-map struct (and, if implemented,
+  the boundary-only `UnifiedColorMap` enum).
+- `compute_field` shape correctness for each fractal: a small synthetic
+  `ImageSpecification` produces a field of the expected concrete type, with
+  the expected size, and the expected values at known points.
 - DDP `#[serde(default)]` shim: an existing pre-Phase-1 DDP JSON
   (re-created in a test fixture) still parses and produces the
   hard-coded white/black colors.
+- Negative serde tests: a JSON with a Mandelbrot params payload but a
+  `MultiColorMap`-shaped color field fails to parse with a structured serde
+  error. (Verifies that mismatched shapes are caught at the JSON boundary,
+  not at runtime.)
 
 ### 10.2 What to manually smoke-test (mandatory each phase)
 
@@ -791,12 +943,17 @@ WSL2/XWayland, native Linux if available.
 | ------------------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------- |
 | JSON migration misses a file                                        | 1     | `tests/example_parameter_validation_tests.rs` glob covers all JSONs; CI catches missed migrations.        |
 | Schema migration changes pixel hashes                               | 1     | Pixel-hash regression tests gate the PR; if hashes change, the migration changed semantics — bug.         |
-| C0b refactor breaks pixel hashes                                    | 2     | Pure refactor; pixel-hash tests are the gate.                                                             |
-| `colorize` too slow at 4K to be live                                | 6     | Benchmark over representative `SmoothScalar` field at 4K early in Phase 6. Falls back to Phase 7 work.    |
+| Compute/color split breaks pixel hashes                             | 2     | Pure refactor; pixel-hash tests are the gate.                                                             |
+| `colorize_into` too slow at 4K to be live                           | 6     | Benchmark over a representative `SmoothScalarField` at 4K early in Phase 6. Falls back to Phase 7 work.   |
 | Newton tab count drifts from `color_maps.len()`                     | 4, 6  | Tab strip is a pure view of `color_maps.iter().enumerate()`; no separately stored count.                  |
-| Variant mismatch (e.g. Mandelbrot params with `MultiColorMap`)      | 1     | Renderer panics with clear message at construction. Authoring-time error, never reachable from valid use. |
 | Editor state desync after `MultiColorMap` tab switch                | 4, 6  | Selection state resets on tab change (specified in §7.2).                                                 |
 | Adaptive regulator behaves badly during color editing               | 6, 7  | Regulator self-tunes; if behavior is wrong, Phase 7 adjusts whether color edits feed `user_interaction`.  |
+
+Variant-mismatch is intentionally not on this list: the typed-pairing design
+(§5) makes it unrepresentable. The only way for a wrong-shape color map to
+reach the renderer is via malformed JSON, which fails serde deserialization
+before any fractal object is constructed. The `_ => panic!` arm that an
+earlier design relied on does not exist.
 
 ---
 
@@ -849,12 +1006,12 @@ these automatically when committing via Claude Code.
 These do not block any phase but should be decided as the relevant phase
 lands.
 
-1. **Variant slack at the type level.** Each fractal stores
-   `color: UnifiedColorMap` as the full enum but only ever uses one variant.
-   If this becomes painful in practice (e.g. lots of `match` arms doing
-   `_ => panic!`), consider introducing typed wrappers at the params level
-   (`BackgroundWithColorMap` as its own struct that `Into<UnifiedColorMap>`).
-   Default: live with the slack; revisit if it bites.
+1. **Whether to keep the `UnifiedColorMap` / `CachedField` boundary enums
+   at all.** Per §5.4 they exist only as opt-in upcasts for diagnostic /
+   cross-fractal tooling. If no caller in this roadmap needs them, drop them
+   — the per-variant concrete structs and `ColorMapKind` trait alone are
+   sufficient. Recommendation: skip in Phase 1; introduce later only if a
+   real caller appears.
 2. **Active Newton tab on switch.** When the active tab changes, reset
    keyframe selection. Recommended.
 3. **Reuse of `paint_gradient_bar`.** The current
@@ -864,9 +1021,10 @@ lands.
 4. **Color edits → adaptive regulator?** Whether to feed color edits into
    `user_interaction = true`. Defer to Phase 7 measurement.
 5. **DDP basin coloring richness.** Today DDP collapses all non-zero basins
-   into one "background" bucket. Future work could expose per-basin colors,
-   which would require extending `UnifiedColorMap` with a richer DDP variant
-   (or adopting `MultiColorMap` for DDP). Out of scope for this roadmap.
+   into one "background" bucket. Future work could expose per-basin colors;
+   the cleanest path is probably to add a fourth `ColorMapKind` impl
+   (e.g. `IndexedBasins`) paired with `BinaryBasinField` rather than
+   stretching `ForegroundBackground`. Out of scope for this roadmap.
 
 ---
 

--- a/docs/gui-unification-roadmap.md
+++ b/docs/gui-unification-roadmap.md
@@ -1,11 +1,18 @@
-# GUI Unification Roadmap
+# GUI Unification & Color-Sync Roadmap
 
-This document describes the multi-phase plan to consolidate the project onto a
-single cross-platform GUI architecture built on `eframe`/`egui`, on Rust 2024
-edition, while eliminating legacy `pixels` + hand-rolled `winit` code paths.
+This document is the canonical roadmap for the multi-phase plan to consolidate
+the project onto a single cross-platform GUI architecture built on
+`eframe`/`egui`, and to deliver a unified interactive experience that combines
+fractal exploration with live color-map editing.
 
 **Audience:** a new agent or contributor picking up the GUI work. This doc is
 self-contained — no prior conversation context is needed.
+
+**Scope:** everything from current state through to the end of "live color
+edits visibly synced into the fractal preview." Out of scope: parameter
+inspector panels, live fractal-type switching, support for fractal types not
+already explorable today (BarnsleyFern, Serpinsky), undo/redo,
+drag-and-drop on keyframes, save-back to the original input JSON.
 
 ---
 
@@ -13,137 +20,110 @@ self-contained — no prior conversation context is needed.
 
 The binary ships with exactly two modes:
 
-1. **Headless render mode** (CLI: `fractal-renderer render ...`) — unchanged
-   from today. Writes images to disk based on a params JSON file. No GUI.
-2. **Interactive mode** (CLI: `fractal-renderer interactive ...` or similar) —
-   a single unified GUI window that combines:
-   - Fractal preview (pan/zoom/click, as `explore` mode does today)
-   - Color map editor (gradient bar, keyframe editing, as the color editor does
-     today)
-   - Parameter inspector (view/edit fractal params live)
+1. **Headless render mode** (`fractal-renderer render <params.json>`) —
+   unchanged. Writes images to disk based on a params JSON file. No GUI.
+2. **Interactive mode** (`fractal-renderer explore <params.json>`) — a single
+   unified GUI window that combines:
+   - Fractal preview (pan/zoom/click).
+   - Color-map editor (per-keyframe color + position, multi-gradient tabs for
+     Newton).
+   - Live preview updates as colors are edited.
+   - Snapshot-to-disk via Space, capturing both the fully-rendered image and
+     the synced parameter JSON (the saved JSON, when re-loaded, restores the
+     GUI to exactly the captured state).
 
-The interactive mode is built entirely on `eframe` (egui's official framework),
-with a **background render thread** feeding a `TextureHandle` for live updates.
+Built entirely on `eframe` (egui's official framework), with a background
+render thread feeding a `TextureHandle` for live updates.
 
-**What disappears:**
+**What disappears over the course of this roadmap:**
 
-- `pixels` crate and everything that depends on it
-- Direct `winit` usage (eframe owns the event loop)
-- The `cli/explore.rs` + `core/user_interface.rs` hand-rolled event loop
-
----
-
-## 2. Current State (as of branch landing this roadmap)
-
-### What exists today
-
-Two independent GUI code paths share no infrastructure:
-
-| Mode         | File                                           | Framework                                | Dependencies           |
-| ------------ | ---------------------------------------------- | ---------------------------------------- | ---------------------- |
-| Explore mode | `src/core/user_interface.rs` (~365 lines)      | hand-rolled `winit 0.28` + `pixels 0.13` | no egui                |
-| Color editor | `src/core/color_map_editor_ui.rs` (~310 lines) | `eframe 0.22` (`egui 0.22`)              | no direct winit/pixels |
-
-### Recent work landed on the `color-gui/...` branch
-
-1. Migrated color editor from hand-rolled `pixels` + `egui-wgpu` + `egui-winit`
-   to `eframe 0.22`. Shrank the file ~185 lines.
-2. Set `panel_fill = BLACK`, `bg_stroke = NONE`, `show_separator_line(false)`
-   to eliminate egui's default separator lines.
-3. Overrode panel frames with `Frame::none().fill(BLACK)` to eliminate
-   sub-pixel gap artifacts at panel boundaries.
-4. Replaced `SidePanel::exact_width` with `default_width` + `width_range` so
-   the editor pane is actually resizable by dragging.
-5. Replaced the gradient bar's `line_segment` loop with `rect_filled`
-   (contiguous rectangles) to eliminate 1-logical-pixel stroke artifacts at
-   fractional DPI.
-6. Added defensive `ctx.request_repaint()` at the end of `App::update()` to
-   self-correct from silently-dropped resize events on WSL/XWayland.
-
-### Known bugs that remain (platform-level, not fixable on eframe 0.22)
-
-| Bug                                              | Platform             | Cause                                                                                 | Fix                              |
-| ------------------------------------------------ | -------------------- | ------------------------------------------------------------------------------------- | -------------------------------- |
-| Window can't be dragged between monitors         | Windows (mixed DPI)  | `winit 0.28` `WM_DPICHANGED` feedback loop                                            | winit 0.29+ (via eframe 0.24+)   |
-| Resize events silently dropped at fractional DPI | WSL/XWayland         | `winit 0.28` bug on Wayland scale changes                                             | winit 0.29.9+ (via eframe 0.24+) |
-| No resize handles                                | WSL (some X servers) | X11 forwarding with no window manager — eframe already requests decorations correctly | environment-level (run a WM)     |
+- The legacy `pixels` crate and direct `winit` usage (already removed in
+  Phases A+B; see §2).
+- The `color_swatch` CLI subcommand and its supporting code.
+- The standalone `color-gui-demo` example (folded into `explore`).
+- The two separate eframe apps ([src/core/user_interface.rs](../src/core/user_interface.rs)
+  and [src/core/color_map_editor_ui.rs](../src/core/color_map_editor_ui.rs)),
+  absorbed into a unified `src/core/interactive/` module.
 
 ---
 
-## 3. Hard Constraints
+## 2. Current State (post Phases A+B)
 
-These are non-obvious gotchas discovered during the color editor migration.
-Any future work must account for them.
+Phases A (port explore mode to eframe; remove `pixels`) and B (Rust edition
+2024 + eframe 0.34) have already landed on `main`. The current state:
 
-### 3.1 The `wgpu_core` linker conflict
+### Dependencies
 
-`wgpu_core` exports `#[no_mangle]` C symbols. Two versions of `wgpu_core` in
-the same binary → **linker error** (duplicate symbols), not just a warning.
+```toml
+edition = "2024"
+eframe = { version = "0.34", default-features = false, features = ["wgpu", "x11", "wayland"] }
+egui = "0.34"
+# pixels and direct winit have been removed entirely.
+```
 
-This means: **all crates that transitively depend on wgpu must share a
-version.** Currently:
+### Two independent eframe apps share no infrastructure
 
-- `pixels 0.13` → `wgpu 0.16`
-- `eframe 0.22` → `wgpu 0.16` ✓ (coincidentally matches)
-- `eframe 0.24, 0.25, 0.26, 0.27` → `wgpu 0.19`
-- `eframe 0.28` → `wgpu 0.20`
-- `eframe 0.29+` → `wgpu 0.20+`
+| Mode         | File                                                                                           | Status                                                       |
+| ------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Explore      | [src/core/user_interface.rs](../src/core/user_interface.rs)                                    | `eframe::App`; preview-only; full pan/zoom/save behavior     |
+| Color editor | [src/core/color_map_editor_ui.rs](../src/core/color_map_editor_ui.rs)                          | `eframe::App`; demo widgets only — does not affect renderer  |
 
-- `pixels 0.13` → `wgpu 0.16`
-- `pixels 0.14` → `wgpu 0.17`
-- `pixels 0.15` → `wgpu 0.19`
-- `pixels 0.16` → `wgpu 0.29`
+Both apps share [src/core/eframe_support.rs](../src/core/eframe_support.rs) for
+`wgpu` setup, but everything else is duplicated.
 
-**Implication:** as long as the explore mode uses `pixels`, it constrains
-`eframe` to a compatible version. The only way to upgrade `eframe` past 0.22
-without dep-tree conflicts is to **remove `pixels` first** (by porting explore
-mode to eframe).
+### CLI
 
-### 3.2 The `raw-window-handle` conflict
+[src/cli/args.rs](../src/cli/args.rs) defines three subcommands: `Render`,
+`Explore`, `ColorSwatch`. The `Explore` subcommand dispatches in
+[src/cli/explore.rs](../src/cli/explore.rs) on the `FractalParams` variant:
+Mandelbrot/Julia/DDP go through generic `PixelGrid<F>`; Newton has its own
+explore path in [src/fractals/newtons_method.rs:461](../src/fractals/newtons_method.rs#L461).
+BarnsleyFern and Serpinsky panic with "ERROR: Parameter type does not yet
+implement RenderWindow" — they are intentionally out of scope for `explore`.
 
-`pixels 0.14+` uses `raw-window-handle 0.6`. `winit 0.28` uses
-`raw-window-handle 0.5`. These version numbers are mutually incompatible at
-the trait level — you cannot pass a `&winit::Window` (RWH 0.5) to a
-`pixels::Pixels::new` (RWH 0.6).
+### Color-map representations (the central problem this roadmap addresses)
 
-**Implication:** `pixels` and `winit` versions are coupled too. You can't mix
-`pixels 0.14+` with `winit 0.28`.
+The three explorable fractal families today use structurally different color
+representations:
 
-### 3.3 Rust edition requirements
+| Fractal              | Representation                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------------- |
+| Mandelbrot, Julia    | `ColorMapParams` = 1 gradient + 1 flat background ([src/fractals/quadratic_map.rs:19](../src/fractals/quadratic_map.rs#L19)) |
+| Driven-damped pendulum | No color params at all — hard-coded white/black in `render_point` ([src/fractals/driven_damped_pendulum.rs:38-44](../src/fractals/driven_damped_pendulum.rs#L38-L44)) |
+| Newton's method      | `CommonParams` with `boundary_set_color_rgb` + `cyclic_attractor_color_rgb` + `ColorMapSpec` enum (FullColorSpec or GrayscaleSpec) ([src/fractals/newtons_method.rs:204-266](../src/fractals/newtons_method.rs#L204-L266)) |
 
-- `eframe 0.32+` requires Rust edition 2024.
-- Current `Cargo.toml` declares `edition = "2018"`.
-- Edition 2024 has stricter rules (disjoint closure captures, temporary
-  lifetimes, new reserved keywords like `gen`). A clean codebase usually needs
-  only a handful of fixes, but it's an unknown ripple risk.
-
-**Implication:** jumping to the latest eframe (0.34) requires a Rust edition
-bump as a prerequisite. eframe 0.27 is the highest version that still compiles
-on edition 2018/2021.
-
-### 3.4 eframe API shifts between 0.22 and latest
-
-When upgrading, expect these mechanical changes:
-
-| 0.22                                   | 0.24+                                                         | 0.28+                                                         |
-| -------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
-| `initial_window_size: Some(vec2(w,h))` | `viewport: ViewportBuilder::default().with_inner_size([w,h])` | same                                                          |
-| `frame.close()`                        | `ctx.send_viewport_cmd(ViewportCommand::Close)`               | same                                                          |
-| `Box::new(\|cc\| Box::new(App))`       | same                                                          | `Box::new(\|cc\| Ok(Box::new(App)))`                          |
-| `egui::Image::new(&tex, size)`         | `Image::new(&tex).fit_to_exact_size(size)`                    | same                                                          |
-| `egui::style::Margin`                  | `egui::Margin`                                                | same                                                          |
-| `DragValue::clamp_range`               | deprecated → `.range()`                                       | same                                                          |
-| `App::update` method                   | same                                                          | same (but `App::ui` preferred in 0.34)                        |
-| Linux needs features                   | `eframe = { features = ["wgpu"] }`                            | `eframe = { features = ["wgpu", "x11", "wayland"] }` (v0.30+) |
+Unifying these is Phase 1.
 
 ---
 
-## 4. Cross-Platform Learnings
+## 3. Phase Roadmap Summary
 
-Distilled from cross-platform testing on Windows native, WSL2/XWayland, and
-code-level investigation of winit/egui/pixels source.
+| Phase | Title                          | Blast radius                                          |
+| ----- | ------------------------------ | ----------------------------------------------------- |
+| 1     | Color-map data unification     | All fractal params + every example/test JSON file     |
+| 2     | Compute / color split          | `Renderable` trait + each fractal's render pipeline   |
+| 3     | Unified `FractalApp` shell     | New `src/core/interactive/` module; preview only      |
+| 4     | Color editor panel             | Editor widget + layout wiring                         |
+| 5     | CLI + cleanup + Space-as-save  | Delete legacy modules; extend snapshot behavior       |
+| 6     | Live color sync                | `PixelGrid` extended with re-colorize-only path       |
+| 7     | Polish                         | Contents TBD post-Phase-6 measurement                 |
 
-### 4.1 Border/line artifacts at panel boundaries
+Phases 1 and 2 are independent pre-work — either order works, but Phase 1 is
+recommended first so Phase 2's `colorize` function can target `UnifiedColorMap`
+directly rather than per-fractal types it would later have to migrate.
+
+Phases 3 → 6 are sequential. Phase 7 is opportunistic.
+
+Each phase is a self-contained PR, bisectable, independently revertible.
+
+---
+
+## 4. Hard Constraints & Cross-Platform Learnings
+
+These are preserved from cross-platform work during Phases A+B. They remain
+relevant to any GUI work going forward.
+
+### 4.1 Border / line artifacts at panel boundaries
 
 **Symptom:** thin white or gray lines appear between `SidePanel` and
 `CentralPanel` when the window is maximized or fullscreen, especially at
@@ -162,296 +142,667 @@ fractional DPI.
    two physical pixels (e.g. `paint_gradient_bar` using `line_segment`).
    → Fix: use `painter.rect_filled` with contiguous rectangles instead.
 
-See `src/core/color_map_editor_ui.rs` for the current implementation that
-applies all three fixes.
+Both existing apps already apply these fixes; the unified app must too.
 
 ### 4.2 Resize event drops on WSL/XWayland
 
-**Symptom:** window appears not to resize at all, or content stops updating
-when the user drags the window edge.
+**Symptom:** window appears not to resize, or content stops updating when the
+user drags the window edge.
 
-**Root cause:** `winit 0.28` on Wayland can drop resize events when the scale
-factor changes. Fixed in `winit 0.29.9`.
+**Mitigation:** call `ctx.request_repaint_after(IDLE_TICK)` at the end of
+every `update()` so eframe re-polls surface size every ~100ms. Already
+implemented in both apps (see [src/core/user_interface.rs:259](../src/core/user_interface.rs#L259)).
 
-**Mitigation on old winit:** `ctx.request_repaint()` at the end of `update()`
-forces eframe to re-poll surface size every frame, self-correcting on the
-next paint cycle. Cost is modest since egui still short-circuits painting
-when nothing changed.
+### 4.3 egui panel width locking
 
-**Real fix:** upgrade eframe to 0.24+ (pulls in winit 0.29+).
+`SidePanel::exact_width(w)` clamps `width_range` to `w..=w`, making the panel
+non-resizable even though the resize drag handle still renders. **Use
+`default_width(w).width_range(min..=max)` instead.**
 
-### 4.3 Windows multi-monitor drag stuck
+### 4.4 Adaptive device limits
 
-**Symptom:** dragging a window between monitors with different DPI scales
-causes the window to stutter and snap back to the original monitor, or get
-"stuck" at the boundary.
+`wgpu_core` rejects requests for limits the GPU doesn't expose
+(`max_color_attachments`, etc.). Virtualized and software drivers
+(WSL/XWayland, llvmpipe) routinely expose only 2-4. Solution lives in
+[src/core/eframe_support.rs](../src/core/eframe_support.rs): clone the
+adapter's own limits into the device descriptor. Both existing apps go through
+this helper; the unified app must too.
 
-**Root cause:** `winit 0.28`'s `WM_DPICHANGED` handler repositions the window
-during drag, which can trigger another `WM_DPICHANGED` event, creating a
-feedback loop. The pixel-by-pixel nudge logic in
-`winit/src/platform_impl/windows/event_loop.rs` lines ~2248-2259 is bounded
-but still visible to the user.
+### 4.5 Wgpu version coupling (no longer load-bearing, but worth knowing)
 
-**Mitigation:** none available on winit 0.28. Fixed in winit 0.29+.
-
-### 4.4 No resize handles on WSL
-
-**Symptom:** the window has no visible resize borders; can't drag edges.
-
-**Root cause:** environmental, not a code bug. eframe correctly passes
-`decorated(true)` and `resizable(true)` to winit. On X11, window decorations
-(title bar, resize borders) are provided by the **window manager** — WSL's X
-server may not provide one.
-
-**Mitigation:** run a window manager (`openbox`, `fluxbox`) alongside the X
-server. Not fixable in-repo.
-
-### 4.5 egui panel width locking
-
-**Gotcha:** `SidePanel::exact_width(w)` does NOT just set the initial width —
-it clamps `width_range` to `w..=w`, making the panel non-resizable even
-though the resize drag handle still renders (just does nothing on drag).
-
-**Fix pattern:** use `default_width(w).width_range(min..=max)` instead.
+`wgpu_core` exports `#[no_mangle]` C symbols. Two versions in the same binary
+→ linker error. This is why `pixels` had to be removed before `eframe` could
+be upgraded. The dep tree is now clean (`eframe 0.34` only); future
+upgrades within the eframe family are unconstrained.
 
 ---
 
-## 5. Roadmap
+## 5. Data Model
 
-Four phases, each a self-contained PR. Each phase is bisectable and
-independently revertible.
+Two paired enums underpin the entire roadmap. The pairing is structural: each
+`UnifiedColorMap` variant has exactly one matching `CachedField` variant, and
+every fractal type fixes the variant pair it uses.
 
-### Phase A: Port explore mode to eframe (on eframe 0.22)
-
-**Goal:** unify the GUI framework. Remove `pixels` from the dep tree. Leave
-everything else stable.
-
-**Why eframe 0.22 specifically?** To minimize moving parts. The explore
-mode's _migration_ is a big change; combining it with an eframe version bump
-would make a bad PR. Do the version bump in Phase B, after the framework is
-unified.
-
-**Scope:**
-
-- Rewrite `src/core/user_interface.rs` as an `eframe::App` implementation.
-- Convert the CPU fractal buffer to `egui::ColorImage` → `TextureHandle`
-  each frame the fractal changes.
-- Replace `RawInputState` with `ctx.input()`.
-- Replace `pixels.window_pos_to_pixel(...)` with math derived from
-  `ui.min_rect()` and the fractal image aspect ratio.
-- Delete `pixels` dep from `Cargo.toml`.
-- Delete direct `winit` dep from `Cargo.toml` (eframe re-exports what's
-  needed).
-- Keep the background-ish render model: `PixelGrid` / `RenderWindow` in
-  `src/core/render_window.rs` probably need small signature changes
-  (e.g. accept `&mut ColorImage` or a raw `&mut [u8]` instead of
-  `pixels.frame_mut()`).
-
-**Risks:**
-
-- `TextureHandle::set()` performance at 60+ Hz during pan/zoom. The explore
-  mode re-renders continuously during interaction. Must benchmark early.
-- Input semantics differ: `winit` keyboard events vs. `egui::Key`. Key
-  mappings need a translation layer (or just use egui keys directly).
-- Mouse-click-to-center behavior: needs to convert pointer position from
-  egui `Pos2` in the fractal image's rect back to fractal space.
-
-**De-risk first:**
-
-- Spike: measure `TextureHandle::set(ColorImage)` + `egui::Image` render cost
-  at 1920×1080, 100 Hz. If it's over 3ms/frame on target hardware, redesign
-  (e.g. use `egui_wgpu::CallbackTrait` for a custom wgpu render pass that
-  reuses an existing GPU texture).
-
-**Expected outcome:**
-
-- Explore mode works identically, but now cross-platform (inherits eframe's
-  correct DPI/resize/multi-monitor handling — though still on winit 0.28's
-  bugs until Phase B).
-- Single Cargo.toml has just `eframe` + `egui` for GUI; no `pixels`, no
-  direct `winit`.
-- Both GUIs share the eframe App trait pattern.
-
-### Phase B: Modernize the stack (edition 2024 + eframe 0.34)
-
-**Prerequisite:** Phase A complete (no pixels/winit dep conflicts).
-
-**Scope:**
-
-- `Cargo.toml`: `edition = "2018"` → `edition = "2024"`.
-- Bump `eframe = "0.22"` → `"0.34"` and `egui = "0.22"` → `"0.34"`.
-- Fix the mechanical API shifts listed in §3.4.
-- Fix any Rust 2024 edition issues surfaced by `cargo check`:
-  - Disjoint closure captures may require explicit `&` or `&mut` in
-    closures.
-  - New reserved keywords (`gen`, `try`) — unlikely to affect this codebase.
-  - Temporary lifetime rule tightening — may need rebinding in a few
-    places.
-- Verify CI is green on all checks (`cargo fmt`, `cargo clippy -D warnings`,
-  `cargo test`, `cargo bench --no-run`).
-- Update MSRV in CI config if relevant.
-
-**Expected outcome:**
-
-- Fully modern Rust + eframe stack.
-- WSL resize-event drops and Windows multi-monitor-drag bugs fixed (via
-  winit 0.29+).
-- Latest egui widget set available for Phase C.
-
-**Risks:**
-
-- Edition 2024 ripple fixes could touch unrelated files (fractals modules,
-  core modules). Allot time for discovery.
-- egui 0.34 may have renamed or restructured widgets we use (especially
-  `egui::color_picker`, `Image`, `Slider` step/clamp APIs). Each needs
-  individual verification.
-
-### Phase C: Merge into a unified `FractalApp`
-
-**Prerequisite:** Phase B complete.
-
-**Goal:** one `eframe::App` implementation serves both interactive
-workflows.
-
-**Design to settle (not yet decided):**
-
-- **Layout:** likely a central fractal preview with docked panels:
-  - Right panel: color map editor (expandable)
-  - Left panel or top bar: fractal parameters (kind, iterations, bounds,
-    etc.)
-  - Bottom status: coordinates under cursor, render progress
-- **State model:** a single `FractalAppState` struct holding:
-  - Current `FractalParams` (the JSON type)
-  - Latest rendered `Vec<Vec<Rgb<u8>>>` buffer + its resolution
-  - `dirty: bool` flag per subsystem (view, params, colors)
-  - `egui::TextureHandle` for the preview
-- **Threading model:** background thread owns the render pipeline. UI thread
-  sends commands (center, zoom, params-change) via channel; background
-  thread posts completed buffers back via channel or shared
-  `Arc<Mutex<Option<Buffer>>>`.
-- **Redraw signaling:** `ctx.request_repaint()` from the UI side when input
-  changes; background thread calls `ctx.request_repaint()` after posting a
-  new buffer.
-
-**Scope:**
-
-- Move `explore` and `color_editor_ui` logic into a new
-  `src/core/interactive/` module with submodules for panels.
-- Wire up a single CLI subcommand (`interactive`) that takes a params JSON
-  file and opens the unified GUI.
-- Delete `src/cli/explore.rs` or keep it as a thin wrapper that calls the
-  new interactive entry point with explore-focused defaults.
-- Delete or quarantine the old `color_map_editor_ui.rs` once everything is
-  in the new module.
-
-### Phase D: Live color adjustment
-
-**Prerequisite:** Phase C complete.
-
-**Two sub-phases:**
-
-#### D1. Color adjustments without re-rendering the fractal
-
-Key insight: for escape-time fractals (Mandelbrot, Julia), the _histogram_
-or _escape count grid_ doesn't depend on the color map — only the final
-pixel coloring does. If we cache the escape-count grid, we can re-color
-instantly on a palette change.
-
-**Scope:**
-
-- Refactor `Renderable` (or add a parallel trait) so the compute and color
-  phases are separable:
-  - `compute_escape_grid() -> EscapeGrid`
-  - `color_grid(grid: &EscapeGrid, color_map: &ColorMap) -> ColorImage`
-- Cache the `EscapeGrid` in the app state; re-color on any color edit.
-- The gradient bar editing in the color panel → immediately re-colors the
-  preview (target: <1 frame latency).
-
-**What fractals this works for:** Mandelbrot, Julia, Newton's. Not
-Barnsley fern (no escape count, it's an IFS), not pendulum (phase
-portrait). Those need full re-render on color change — acceptable because
-they're not the common color-editing case.
-
-#### D2. Full dynamic parameter adjustment
-
-Backend param changes (iteration cap, view bounds, fractal kind) trigger a
-full re-render in the background thread. UI stays responsive with:
-
-- Debounce param changes by ~100ms to batch rapid slider edits.
-- Render at reduced resolution first (1/4 res), upgrade to full res when
-  interaction idles for ~500ms.
-- Cancellation: if a new render is requested while one is in flight, abort
-  the in-flight render (check a `stop_flag: Arc<AtomicBool>` in the
-  fractal hot loop).
-
----
-
-## 6. Architecture & File Map
-
-### Files central to the GUI (current state)
-
-| File                              | Role                               | Phase that touches it                            |
-| --------------------------------- | ---------------------------------- | ------------------------------------------------ |
-| `src/core/color_map_editor_ui.rs` | Color editor `eframe::App`         | A (port reference), C (merge)                    |
-| `src/core/user_interface.rs`      | Explore mode event loop            | A (rewrite), C (delete or absorb)                |
-| `src/core/render_window.rs`       | `PixelGrid`/`RenderWindow` helpers | A (minor signature changes)                      |
-| `src/cli/explore.rs`              | Thin CLI wrapper                   | A (no change), C (delete or wrap)                |
-| `src/core/view_control.rs`        | Pan/zoom math                      | C (reuse)                                        |
-| `src/core/color_map.rs`           | Color interpolation                | D1 (reuse for re-coloring)                       |
-| `src/core/image_utils.rs`         | `Renderable` trait                 | D1 (split compute/color)                         |
-| `examples/common/mod.rs`          | Calls `run_color_editor`           | A, C (update call)                               |
-| `Cargo.toml`                      | Deps                               | A (remove pixels/winit), B (bump eframe/edition) |
-
-### Key trait: `Renderable`
-
-Defined in `src/core/image_utils.rs`. Currently:
+### 5.1 `UnifiedColorMap`
 
 ```rust
-pub trait Renderable {
-    fn render_to_buffer(&self, buffer: &mut Vec<Vec<image::Rgb<u8>>>);
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum UnifiedColorMap {
+    /// Two flat colors. Every pixel belongs to one of two classes; no
+    /// gradient information. Used by the driven-damped pendulum.
+    ForegroundBackground {
+        foreground: [u8; 3],
+        background: [u8; 3],
+    },
+
+    /// One flat background plus one gradient. The flat color is for points
+    /// that don't produce a graded output (e.g. inside the Mandelbrot set);
+    /// the gradient is sampled by a normalized scalar (smooth escape count).
+    /// Used by Mandelbrot and Julia.
+    BackgroundWithColorMap {
+        background: [u8; 3],
+        color_map: Vec<ColorMapKeyFrame>,
+    },
+
+    /// One flat color plus one gradient per attractor. The flat covers
+    /// "did-not-converge" points; each attractor gets its own gradient
+    /// sampled by a smooth iteration count. Used by Newton's method.
+    MultiColorMap {
+        cyclic_attractor: [u8; 3],
+        color_maps: Vec<Vec<ColorMapKeyFrame>>,
+    },
 }
 ```
 
-All fractal modules (`src/fractals/*.rs`) implement this. Phase D1 will
-likely split this into compute + color phases.
+Variant names are descriptive (what the structure is), not fractal-named.
+Newton's `boundary_set_color_rgb` is intentionally absent: it is dead code in
+the renderer ([src/fractals/newtons_method.rs:416-428](../src/fractals/newtons_method.rs#L416-L428)
+never reads it) and exists today only to define the "in-set" endpoint of the
+`GrayscaleSpec` shorthand, which Phase 1 drops.
+
+### 5.2 `CachedField`
+
+```rust
+pub enum CachedField {
+    /// Per-pixel basin index. Used by the driven-damped pendulum.
+    BinaryBasin(Vec<Vec<Option<i32>>>),
+
+    /// Per-pixel smooth escape count. Used by Mandelbrot and Julia.
+    SmoothScalar(Vec<Vec<Option<f32>>>),
+
+    /// Per-pixel (smooth iteration count, attractor index). Used by
+    /// Newton's method.
+    SmoothScalarWithIndex(Vec<Vec<Option<(f32, usize)>>>),
+}
+```
+
+### 5.3 Pairing table
+
+| `UnifiedColorMap` variant | `CachedField` variant      | Fractal                  | Colorization rule                                                                  |
+| ------------------------- | -------------------------- | ------------------------ | ---------------------------------------------------------------------------------- |
+| `ForegroundBackground`    | `BinaryBasin`              | DDP                      | `Some(0)` → `foreground`; `Some(_)` or `None` → `background`                       |
+| `BackgroundWithColorMap`  | `SmoothScalar`             | Mandelbrot, Julia        | `None` → `background`; `Some(f)` → `color_map.lookup(f)`                           |
+| `MultiColorMap`           | `SmoothScalarWithIndex`    | Newton's method          | `None` → `cyclic_attractor`; `Some((f, k))` → `color_maps[k].lookup(f)`            |
+
+The free function `colorize(field: &CachedField, map: &UnifiedColorMap) ->
+ColorImage` matches on the `(field, map)` tuple. Mismatched variants
+(`BinaryBasin` × `BackgroundWithColorMap`, etc.) panic with a clear "wiring
+bug" message — by construction this case never arises from valid params files,
+since each fractal's `Renderable` impl returns the correct `CachedField`
+variant and embeds the matching `UnifiedColorMap` variant.
+
+### 5.4 Why the typed enum (vs a `Vec<LabeledGradient>` flat list)
+
+Considered earlier and rejected:
+
+- A flat `Vec<LabeledGradient>` would require positional conventions
+  ("entry 0 is always background, entries 1..N are gradients") that are easy
+  to drift between editor and renderer, and the editor would still need a
+  "is this a flat color or a gradient?" discriminator per entry, plus a
+  per-fractal label lookup table.
+- The typed enum gives compiler-enforced exhaustiveness, role-as-data
+  (no positional contract), no round-trip conversion at the editor/renderer
+  boundary, and small editor dispatch (one match arm per variant, ~25 LoC,
+  with shared `show_swatch` / `show_gradient_editor` widget helpers).
 
 ---
 
-## 7. Dependency Version Matrix
+## 6. Phase Detail
 
-### Current (as of this doc's landing branch)
+### Phase 1 — Color-map data unification
 
-```toml
-eframe = { version = "0.22", default-features = false, features = ["wgpu"] }
-egui = "0.22"
-pixels = "0.13"
-winit = "0.28"
+**Goal:** every fractal type embeds `UnifiedColorMap` directly in its params
+struct. JSON schema migrates accordingly. No GUI work.
+
+**Files touched:**
+
+- [src/core/color_map.rs](../src/core/color_map.rs) — define `UnifiedColorMap`.
+- [src/fractals/quadratic_map.rs](../src/fractals/quadratic_map.rs) — replace
+  `ColorMapParams.keyframes` and `background_color_rgb` with `color:
+  UnifiedColorMap` (constrained to `BackgroundWithColorMap`). The other
+  `ColorMapParams` fields (`lookup_table_count`, `histogram_bin_count`,
+  `histogram_sample_count`) are not color data and stay on `QuadraticMapParams`
+  directly (or move into a sibling struct — implementer's choice).
+- [src/fractals/mandelbrot.rs](../src/fractals/mandelbrot.rs),
+  [src/fractals/julia.rs](../src/fractals/julia.rs) — automatic via the
+  `QuadraticMapParams` trait change.
+- [src/fractals/driven_damped_pendulum.rs](../src/fractals/driven_damped_pendulum.rs)
+  — add `color: UnifiedColorMap` field with
+  `#[serde(default = "ddp_default_color")]`. Default is
+  `ForegroundBackground { foreground: [255,255,255], background: [0,0,0] }`,
+  matching the previously hard-coded values. Replace the literal
+  `Rgb([255,255,255])` / `Rgb([0,0,0])` in `render_point` with reads from the
+  field.
+- [src/fractals/newtons_method.rs](../src/fractals/newtons_method.rs) —
+  replace `boundary_set_color_rgb`, `cyclic_attractor_color_rgb`, and
+  `color_map_spec` in `CommonParams` with a single `color: UnifiedColorMap`
+  field (constrained to `MultiColorMap`). **Drop `GrayscaleSpec` and
+  `GrayscaleKeyframeSpec` entirely**, including the `to_color_map_vec`
+  expansion logic. The `ColorMapSpec` enum can be removed; if its other
+  variant `FullColorSpec` is kept around as an alias type, that's fine, but
+  the simpler path is to delete it too.
+- Every JSON file under [examples/](../examples/), [benches/](../benches/),
+  and [tests/param_files/](../tests/param_files/) that references a fractal
+  whose schema changed. The
+  [examples/explore-newton-roots-of-unity-4/params.json](../examples/explore-newton-roots-of-unity-4/params.json)
+  file (and its render counterpart) currently use `GrayscaleSpec`; expand by
+  hand into 4 explicit per-root gradients.
+- [tests/example_parameter_validation_tests.rs](../tests/example_parameter_validation_tests.rs)
+  — verify still passes against migrated JSONs.
+
+**Verification:** `cargo test` — pixel-hash regression tests in
+[tests/full_cli_integration_and_regression_tests.rs](../tests/full_cli_integration_and_regression_tests.rs)
+must remain unchanged (color computation is logically identical, only the
+schema moved).
+
+**Variant slack:** each fractal's params struct holds `color: UnifiedColorMap`
+typed as the full enum, not a refinement to one variant. Construction-time
+validation (or a `match` in the renderer that panics on the wrong variant)
+catches misuse. The slack is acceptable in exchange for not needing per-fractal
+narrow types.
+
+### Phase 2 — Compute / color split
+
+**Goal:** factor `Renderable` so the per-pixel scalar computation is separated
+from colorization. No observable behavior change; pixel hashes unchanged.
+
+**Files touched:**
+
+- [src/core/image_utils.rs](../src/core/image_utils.rs) — extend `Renderable`
+  trait. Add `CachedField` enum. Add `colorize(field, map)` and
+  `colorize_into(field, map, &mut buffer)` free functions.
+- [src/fractals/quadratic_map.rs](../src/fractals/quadratic_map.rs),
+  [src/fractals/driven_damped_pendulum.rs](../src/fractals/driven_damped_pendulum.rs),
+  [src/fractals/newtons_method.rs](../src/fractals/newtons_method.rs) —
+  implement `compute_field()`; default `render_to_buffer` to
+  `compute_field()` then `colorize_into(...)`. Where today's renderer does
+  histogram/CDF setup that depends on the field but not the keyframes
+  (e.g. [src/fractals/quadratic_map.rs:225](../src/fractals/quadratic_map.rs#L225)),
+  that work happens at the `compute_field` boundary so the per-fractal
+  prep cost is paid once per compute, not once per re-colorize.
+
+**Sketch:**
+
+```rust
+pub trait Renderable: Sync + Send + SpeedOptimizer {
+    type Params: Serialize + Debug;
+
+    fn compute_field(&self) -> CachedField;
+    fn color_map(&self) -> &UnifiedColorMap;
+    // color_map_mut added in Phase 6, not here.
+
+    // Existing methods unchanged: image_specification, render_options,
+    // set_image_specification, write_diagnostics, params, render_point.
+
+    // Default impl rewires through compute + colorize:
+    fn render_to_buffer(&self, buffer: &mut Vec<Vec<Rgb<u8>>>) {
+        let field = self.compute_field();
+        colorize_into(&field, self.color_map(), buffer);
+    }
+}
 ```
 
-Rust edition: **2018**.
+**Unit tests added:** `colorize` correctness for each `(CachedField,
+UnifiedColorMap)` pairing, including edge cases (empty `color_maps` for
+`MultiColorMap`, all-`None` field for each variant, single-keyframe gradients).
 
-### Target after Phase A
+**Verification:** pixel-hash regression tests must pass unchanged. `cargo
+bench --no-run` to confirm benchmarks still compile; `cargo bench` on the
+quadratic-map histogram benchmark to confirm no regression on the hot path.
 
-```toml
-eframe = { version = "0.22", default-features = false, features = ["wgpu"] }
-egui = "0.22"
-# pixels and winit removed entirely
+### Phase 3 — Unified `FractalApp` shell
+
+**Goal:** introduce a new `src/core/interactive/` module hosting a single
+`eframe::App` that handles all four explorable fractal types. Preview only;
+no color editor yet. `Cargo run -- explore <params.json>` continues to work
+across Mandelbrot, Julia, DDP, and Newton — same pan/zoom/click/save
+behavior as today's explore mode.
+
+**Files touched:**
+
+- [src/core/mod.rs](../src/core/mod.rs) — add `pub mod interactive;`.
+- `src/core/interactive/mod.rs` — new; re-exports public API.
+- `src/core/interactive/app.rs` — new; the `FractalApp<F: Renderable>` struct
+  and its `eframe::App` impl. Lifted from
+  [src/core/user_interface.rs](../src/core/user_interface.rs) with no
+  behavior changes.
+- [src/cli/explore.rs](../src/cli/explore.rs) — dispatch on `FractalParams`
+  variant, calling `interactive::run::<F>(...)` instead of
+  `user_interface::explore::<F>(...)`. Newton's separate
+  [src/fractals/newtons_method.rs:461](../src/fractals/newtons_method.rs#L461)
+  `explore_fractal` similarly retargets.
+
+The old [src/core/user_interface.rs](../src/core/user_interface.rs) stays
+in tree at this phase to keep diffs reviewable; it gets deleted in Phase 5.
+
+**Visuals:** `panel_fill = BLACK`, `bg_stroke = NONE`, `Frame::NONE.fill(BLACK)`
+on every panel — matches current explore mode and avoids border artifacts
+(§4.1).
+
+**Verification:** manual smoke-test all four fractal types on Windows native
++ WSL.
+
+### Phase 4 — Color editor panel
+
+**Goal:** add the right-side color editor panel to `FractalApp`. Editor
+displays the loaded `UnifiedColorMap` and allows local mutation of a
+**cached copy**. The fractal preview is not affected by edits — that's
+Phase 6.
+
+**Files touched:**
+
+- `src/core/interactive/editor.rs` — new; per-variant editor widgets,
+  shared helpers (`show_swatch`, `show_gradient_editor`), tab strip for
+  `MultiColorMap`.
+- `src/core/interactive/app.rs` — extend layout: `SidePanel::right` for the
+  editor, `CentralPanel` for the preview. `FractalApp` gains
+  `editor_color_map: UnifiedColorMap` and editor selection state (selected
+  keyframe index, active Newton tab).
+
+**Layout:**
+
+```
+┌─────────────────────────────────────────────┬──────────────────────┐
+│                                             │ Color Map            │
+│                                             │ ───────────────────  │
+│                                             │ [Newton tabs only:]  │
+│                                             │ │Root 0│Root 1│...│  │
+│                                             │ ───────────────────  │
+│         (fractal preview, central)          │ Flat colors:         │
+│                                             │  [swatch] background │
+│                                             │ ───────────────────  │
+│                                             │ Keyframes:           │
+│                                             │  [color cell #0]     │
+│                                             │  [+] [0.25]          │
+│                                             │  [color cell #1]     │
+│                                             │  [+] [0.30]          │
+│                                             │  ...                 │
+│                                             │ ───────────────────  │
+│                                             │ [gradient bar]       │
+│                                             │ ───────────────────  │
+│                                             │ [color picker]       │
+└─────────────────────────────────────────────┴──────────────────────┘
 ```
 
-### Target after Phase B
+Detailed widget spec is in §7.
 
-```toml
-eframe = { version = "0.34", default-features = false, features = ["wgpu", "x11", "wayland"] }
-egui = "0.34"
-```
+**Local-cache lifecycle:** `editor_color_map` is initialized at startup as a
+clone of the renderer's `UnifiedColorMap`. All editor widgets mutate only this
+cache. The renderer continues to use its own (immutable, in this phase) map.
+Edits do not survive window close (no save-back to disk; Space-as-save in
+Phase 5 captures the cache to a fresh timestamped JSON).
 
-Rust edition: **2024**.
+### Phase 5 — CLI + cleanup + extended Space-as-save
+
+**Goal:** retire dead code paths; extend snapshot behavior to capture color
+edits.
+
+**Files touched (deletions):**
+
+- [src/cli/color_swatch.rs](../src/cli/color_swatch.rs) — delete entirely.
+- [src/cli/args.rs](../src/cli/args.rs) — remove `ColorSwatch` variant from
+  `CommandsEnum`.
+- [src/cli/mod.rs](../src/cli/mod.rs) — remove `pub mod color_swatch;`.
+- [src/main.rs](../src/main.rs) — remove `ColorSwatch` dispatch arm and the
+  `use cli::color_swatch::generate_color_swatch` import.
+- [examples/visualize-color-swatch-rainbow/](../examples/visualize-color-swatch-rainbow/) — delete.
+- [examples/color-gui-demo/](../examples/color-gui-demo/) — delete (its
+  functionality is now part of `explore`).
+- [examples/common/mod.rs](../examples/common/mod.rs) — delete
+  `color_swatch_example_from_string` and `color_editor_example_from_string`.
+- [src/core/color_map_editor_ui.rs](../src/core/color_map_editor_ui.rs) —
+  delete; absorbed into `src/core/interactive/editor.rs`.
+- [src/core/user_interface.rs](../src/core/user_interface.rs) — delete;
+  absorbed into `src/core/interactive/app.rs`.
+- [src/core/mod.rs](../src/core/mod.rs) — remove deleted module decls.
+
+**Files touched (extension):**
+
+- `src/core/interactive/app.rs` — implement the new Space-as-save behavior
+  (full spec in §8). At this phase, "sync color map back into renderer"
+  is a one-shot copy from `editor_color_map` into the renderer's params
+  before the snapshot render — Phase 6 turns this into a continuous flow.
+- [src/core/render_window.rs](../src/core/render_window.rs) — `PixelGrid`
+  may need an explicit "render at full quality, then notify" entry point to
+  support the save flow (the existing `render_to_file` path can be retained
+  or rewired; implementer's choice).
+
+**Verification:** all CI green. Manual smoke-test of Space-as-save: load
+example, edit colors, press Space, verify (a) overlay appears, (b) controls
+locked during render, (c) timestamped JSON + PNG written to disk, (d)
+re-loading the saved JSON via `cargo run -- explore <saved.json>` reproduces
+the exact GUI state including colors.
+
+### Phase 6 — Live color sync
+
+**Goal:** color edits in the editor panel cause the fractal preview to
+re-colorize live (target: <1 frame latency at 1080p).
+
+**Approach:** the `CachedField` produced by `compute_field` does not depend
+on the color map, so we cache it after each compute and re-colorize from it
+on every color edit. Re-colorize is pure pixel-level work (no fractal math)
+and is fast enough to run on demand.
+
+**Files touched:**
+
+- [src/core/image_utils.rs](../src/core/image_utils.rs) — add
+  `color_map_mut(&mut self) -> &mut UnifiedColorMap` to `Renderable`.
+- [src/core/render_window.rs](../src/core/render_window.rs) — extend
+  `PixelGrid` to:
+  - Cache the most recent `CachedField` after each compute (alongside the
+    existing `display_buffer`).
+  - Add an `Arc<AtomicBool>` `color_dirty` flag.
+  - In `update()`, if `color_dirty` is set and no compute is in flight,
+    spawn a background task that just re-colorizes the cached field into
+    `display_buffer` (skipping `compute_field`).
+- `src/core/interactive/app.rs` — wire editor edits: when the editor mutates
+  a keyframe / fraction / flat color, write the change into
+  `renderer.color_map_mut()`, set `color_dirty`, call `ctx.request_repaint()`.
+- `src/core/interactive/editor.rs` — return an "edited" boolean from each
+  editor function so the app knows when to set `color_dirty`.
+
+**Editor cache transition:** the separate `editor_color_map` from Phase 4
+becomes redundant. The editor now mutates `renderer.color_map_mut()` directly.
+The app retains only editor *selection* state (selected keyframe index, active
+Newton tab) — the data lives on the renderer.
+
+**Adaptive quality regulator interaction:** color edits trigger only
+re-colorize, not re-compute, so the regulator's compute-quality scaling is not
+mechanically engaged by them. Whether color edits should also feed the
+`user_interaction = true` signal (so the regulator stays in "interactive
+mode" and defers expensive idle-time recomputes) is a UX-feel decision to
+make once Phase 6 is functional. The regulator self-tunes from observed
+compute time, so neither choice is structurally wrong.
+
+**Verification:** manual interactive testing — drag fraction sliders, click
+keyframe colors, verify the preview updates within a frame or two. Benchmark
+`colorize` over a representative `SmoothScalar` field at 1920×1080 and 4K to
+confirm it stays under one frame at 60Hz; if not, Phase 7 must include
+optimization or downscaling for the live path.
+
+### Phase 7 — Polish
+
+Contents to be defined post-Phase-6 measurement. Likely candidates:
+
+- Debouncing rapid slider drags if `colorize` proves expensive at large
+  resolutions.
+- Tuning the defensive `request_repaint_after` cadence.
+- Visual feedback for the selected keyframe (border, highlight).
+- Color picker UX refinements (RGB vs HSV, eyedropper, swatch history).
+- Whether to feed color edits into the adaptive regulator's
+  `user_interaction` signal.
 
 ---
 
-## 8. Working Practices for This Roadmap
+## 7. Color Editor Widget Spec
 
-### CI checks (from `AGENTS.md`/`CLAUDE.md`)
+### 7.1 Single-gradient editor (used by `BackgroundWithColorMap` and each
+`MultiColorMap` tab)
+
+**Read-only displays:**
+
+- Vertical sequence of color cells, one per keyframe. Each cell is a small
+  filled rectangle (~32×32px) showing the keyframe's RGB. Selectable.
+- A horizontal gradient bar showing the full gradient as currently
+  configured. Read-only — no drag-to-edit, no click-to-insert.
+
+**Mutable handles:**
+
+- Between each pair of adjacent keyframes: a `+` button and a `DragValue`
+  showing the *fraction* of the gradient occupied by that segment (the
+  difference between the two adjacent keyframe positions).
+- Inline color picker (egui's `color_picker_color32`), permanently visible
+  at the bottom of the panel.
+
+**Interactions:**
+
+- **Click a color cell** → that keyframe becomes the selected keyframe.
+  The inline color picker switches to editing its color. Live: every picker
+  change writes into the keyframe's `rgb_raw`.
+- **`Delete` key** while a keyframe is selected → that keyframe is removed
+  from the gradient; selection clears; the picker returns to its idle state.
+  The first and last keyframes (positions 0.0 and 1.0) are anchors and
+  cannot be deleted (`Delete` is a no-op on them).
+- **`Escape` key** → clears keyframe selection. Picker returns to its idle
+  state. **`Escape` does not exit the application.**
+- **`+` button** between two adjacent keyframes → inserts a new keyframe at
+  the midpoint of that segment. Default color: linearly interpolated between
+  the two adjacent keyframes (so insertion is initially invisible until the
+  user edits the new keyframe). The `+` button does not appear before the
+  first keyframe or after the last.
+- **Edit a fraction `DragValue`** → that fraction adopts the new value; the
+  *other* fractions are scaled proportionally so the sum stays 1.0; the
+  keyframe positions are recomputed from the resulting fractions. Each
+  fraction is clamped to `[ε, 1.0]` (with `ε ≈ 0.005`) to prevent any
+  segment from collapsing to zero width.
+
+### 7.2 Per-variant layout
+
+- `ForegroundBackground` — two color picker rows: "Foreground" and
+  "Background". No tabs, no keyframe list, no gradient bar.
+- `BackgroundWithColorMap` — one color picker row ("Background") above one
+  single-gradient editor.
+- `MultiColorMap` — one color picker row ("Cyclic attractor") above a tab
+  strip (one tab per entry in `color_maps`), with the active tab showing a
+  single-gradient editor for that gradient. Switching tabs resets keyframe
+  selection (each tab starts unselected).
+
+### 7.3 Application keys (interactive mode)
+
+| Key                | Behavior                                                                         |
+| ------------------ | -------------------------------------------------------------------------------- |
+| Arrow keys         | Pan view (existing).                                                             |
+| W / S              | Zoom in / out (existing).                                                        |
+| A / D (with no W/S)| Fast zoom in / out (existing).                                                   |
+| R                  | Reset to initial view (existing).                                                |
+| Mouse left-click   | Recenter view on clicked point in the fractal preview (existing).                |
+| Space              | Save snapshot — see §8.                                                          |
+| Q                  | Exit application.                                                                |
+| Ctrl+C             | Exit application (terminal default).                                             |
+| Esc                | Clear keyframe selection. **No-op when no keyframe is selected.** Does not exit. |
+| Delete             | Remove selected keyframe (no-op for first/last).                                 |
+
+The Esc-as-quit binding present in today's [src/core/user_interface.rs:216](../src/core/user_interface.rs#L216)
+must be removed.
+
+### 7.4 Out of scope
+
+- Drag-and-drop on the gradient bar or color cells.
+- Arrow-key / Tab navigation between keyframes (click only).
+- Undo / redo.
+- Adding or removing entire gradients (e.g. changing Newton's root count).
+- Reordering keyframes (positions are derived from fractions, which are
+  positive, so order is stable).
+
+---
+
+## 8. Space-as-Save Spec
+
+Pressing Space initiates a deliberate "publish this exact state" action.
+Unlike today's fire-and-forget snapshot, the new flow is gated on a
+full-quality render and locks input until complete.
+
+### 8.1 State machine
+
+```
+Idle ──Space pressed──► Saving ──save complete──► Idle
+                          │
+                          ├── overlay shown
+                          ├── input locked
+                          ├── adaptive regulator forced to level 0
+                          └── re-render in flight
+```
+
+### 8.2 Step sequence
+
+1. **Lock & overlay.** Set `save_in_progress = true`. Display a feedback
+   overlay (translucent panel, "Saving snapshot…"). All input is suppressed
+   for the duration: pan/zoom keys, click-to-center, Space (debouncing
+   double-press), Esc, color edits.
+2. **Force quality to default.** Reset
+   `AdaptiveOptimizationRegulator` so the next render uses
+   `speed_optimization_level = 0.0`. The field will be computed at full
+   user-specified quality, not whatever degraded state interactive use had
+   pushed it to.
+3. **Sync color map.** Push the editor's current `UnifiedColorMap` (which in
+   Phase 6 *is* the renderer's map; in Phase 5 was a separate cache) into the
+   renderer's params for serialization.
+4. **Render to GUI.** Background thread runs `compute_field` (full quality)
+   followed by `colorize` (with synced map) and swaps the result into the
+   preview texture. The save flow blocks (overlay still up) until the render
+   is complete.
+5. **Save params to disk.** Serialize the now-synced `FractalParams`
+   (including embedded `UnifiedColorMap` and the current view-control's
+   `image_specification`) to `<prefix>_<datetime>.json`. The
+   filename pattern matches today's
+   [src/core/render_window.rs:255-261](../src/core/render_window.rs#L255-L261).
+6. **Save image to disk.** Write the just-rendered buffer to
+   `<prefix>_<datetime>.png`. Pixels match what's on screen.
+7. **Unlock.** Clear `save_in_progress`; remove overlay; resume input.
+
+### 8.3 Restorability invariant
+
+Calling `cargo run -- explore <saved.json>` on the file produced by step 5
+must restore the GUI to *exactly* the state it was in when Space was pressed:
+the same view bounds, the same color map (including any edits), the same
+render quality, the same fractal type. The pixel hash of the rendered preview
+should match the saved PNG.
+
+### 8.4 Comparison to current behavior
+
+Today's Space ([src/core/render_window.rs:254-280](../src/core/render_window.rs#L254-L280))
+snapshots whatever the display buffer happens to contain, allowing the user
+to keep interacting during the write. The new flow is the opposite: deliberate
+"publish this exact state" gated on a full-quality render. The user accepts
+a brief block in exchange for guaranteed fidelity between what's on screen,
+what's written to disk, and what re-loads next time.
+
+---
+
+## 9. Threading & Adaptive Quality
+
+### 9.1 Thread layout
+
+- **UI thread:** eframe app — layout, input, editor mutations.
+- **Background thread:** `PixelGrid` worker — runs `compute_field` and
+  `colorize`. The existing `Arc<Mutex<F: Renderable>>` plus
+  `Arc<AtomicBool>` flags pattern stays. Phase 6 adds a `color_dirty` flag
+  alongside the existing `redraw_required` and `render_task_is_busy` flags.
+
+### 9.2 Render trigger matrix
+
+| Event                          | What runs                                  | Quality           |
+| ------------------------------ | ------------------------------------------ | ----------------- |
+| Pan / zoom / click             | `compute_field` + `colorize`               | Adaptive          |
+| Color edit (Phase 6+)          | `colorize` only (uses cached field)        | Full              |
+| Space pressed                  | `compute_field` + `colorize`               | Forced to full    |
+| Idle (no interaction)          | Adaptive regulator may trigger upgrade     | Climbing → full   |
+
+### 9.3 Adaptive regulator
+
+Stays unchanged from today's
+[src/core/render_quality_fsm.rs](../src/core/render_quality_fsm.rs). The
+`user_interaction = true` signal continues to come from view changes. Whether
+to also feed color edits into this signal is **deferred to Phase 7** — the
+regulator self-tunes from observed compute time, so the choice doesn't change
+the architecture, only the UX feel of "how aggressively does quality bounce
+back up after the user stops dragging a slider."
+
+### 9.4 BarnsleyFern and Serpinsky
+
+Continue to panic in `cli::explore::explore_fractal` with "Parameter type does
+not yet implement RenderWindow." Out of scope for this entire roadmap. Their
+params structs are not migrated to `UnifiedColorMap` (Phase 1) and they do not
+implement `compute_field` (Phase 2).
+
+---
+
+## 10. Testing Strategy
+
+**Bar:** strong unit tests on logical pieces; manual smoke testing on the GUI
+itself. Snapshot or behavioral GUI tests are not required for this roadmap
+but may be added later if a particular bug class becomes recurring.
+
+### 10.1 What to unit-test (mandatory)
+
+- `colorize(field, map)` correctness for every `(CachedField, UnifiedColorMap)`
+  pairing, including:
+  - All-`None` field for each variant.
+  - Single-keyframe gradients.
+  - Boundary keyframe values (0.0 and 1.0).
+  - `MultiColorMap` with empty `color_maps` (must error or panic with a
+    clear message — not silently produce garbage).
+- Fraction renormalization: edit one fraction in a 4-keyframe gradient,
+  assert the others scale proportionally and the resulting positions match
+  expectations. Edge cases: edit to ε, edit to 1−ε, edit to 0 (clamped),
+  edit to 1.0 (clamped).
+- Keyframe insertion: `+` between two existing keyframes produces the
+  expected midpoint position and the expected interpolated color.
+- Keyframe deletion: removing the second keyframe in a 3-keyframe gradient
+  preserves positions 0.0 and 1.0 of the anchors and removes the middle one.
+- `UnifiedColorMap` serde round-trips for every variant.
+- `CachedField` construction for each fractal: a small synthetic
+  `ImageSpecification` produces the expected variant with the expected size
+  and the expected entries at known points.
+- DDP `#[serde(default)]` shim: an existing pre-Phase-1 DDP JSON
+  (re-created in a test fixture) still parses and produces the
+  hard-coded white/black colors.
+
+### 10.2 What to manually smoke-test (mandatory each phase)
+
+Per the per-phase PR checklist (§12). Same matrix as today: Windows native,
+WSL2/XWayland, native Linux if available.
+
+### 10.3 What to leave for later
+
+- egui snapshot tests on the editor panel rendering (would require
+  `egui_kittest` or similar dev-dep).
+- Synthetic-input behavioral tests (e.g. "click keyframe 2, press Delete,
+  assert N-1 keyframes").
+- Performance regression tests for `colorize` (initially benchmarked
+  manually in Phase 6; promote to a criterion benchmark if it becomes a
+  recurring concern).
+
+---
+
+## 11. Risks & De-risk
+
+| Risk                                                                | Phase | Mitigation                                                                                                |
+| ------------------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------- |
+| JSON migration misses a file                                        | 1     | `tests/example_parameter_validation_tests.rs` glob covers all JSONs; CI catches missed migrations.        |
+| Schema migration changes pixel hashes                               | 1     | Pixel-hash regression tests gate the PR; if hashes change, the migration changed semantics — bug.         |
+| C0b refactor breaks pixel hashes                                    | 2     | Pure refactor; pixel-hash tests are the gate.                                                             |
+| `colorize` too slow at 4K to be live                                | 6     | Benchmark over representative `SmoothScalar` field at 4K early in Phase 6. Falls back to Phase 7 work.    |
+| Newton tab count drifts from `color_maps.len()`                     | 4, 6  | Tab strip is a pure view of `color_maps.iter().enumerate()`; no separately stored count.                  |
+| Variant mismatch (e.g. Mandelbrot params with `MultiColorMap`)      | 1     | Renderer panics with clear message at construction. Authoring-time error, never reachable from valid use. |
+| Editor state desync after `MultiColorMap` tab switch                | 4, 6  | Selection state resets on tab change (specified in §7.2).                                                 |
+| Adaptive regulator behaves badly during color editing               | 6, 7  | Regulator self-tunes; if behavior is wrong, Phase 7 adjusts whether color edits feed `user_interaction`.  |
+
+---
+
+## 12. Working Practices
+
+### 12.1 CI checks (per [CLAUDE.md](../CLAUDE.md))
 
 Before every commit:
 
@@ -462,83 +813,81 @@ cargo test
 cargo bench --no-run
 ```
 
-Pre-commit hooks in `.claude/settings.json` enforce steps 1–4 automatically
-when committing via Claude Code.
+Pre-commit hooks in [.claude/settings.json](../.claude/settings.json) enforce
+these automatically when committing via Claude Code.
 
-### Branch / commit conventions
+### 12.2 Branch / commit conventions
 
-- Branches: `feature/description`, `fix/description`, `perf/description`
+- Branches: `feature/description`, `fix/description`, `perf/description`,
+  `refactor/description`.
 - Commits: conventional (`feat:`, `fix:`, `perf:`, `refactor:`, `test:`,
-  `docs:`, `chore:`) OR imperative short titles
-- One logical change per commit
+  `docs:`, `chore:`) or imperative short titles.
+- One logical change per commit.
 - Include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` for
-  AI-assisted commits
-- Never push or open PRs without explicit user confirmation
+  AI-assisted commits.
+- Never push or open PRs without explicit user confirmation.
 
-### Per-phase PR checklist
+### 12.3 Per-phase PR checklist
 
-- [ ] All CI green locally
-- [ ] Manual smoke test: `cargo run --example color-gui-demo` (Phase A–B)
-- [ ] Manual smoke test: the interactive binary on Windows native
-- [ ] Manual smoke test: the interactive binary on WSL
-- [ ] Manual smoke test: the interactive binary on native Linux (if
-      available)
-- [ ] Benchmark comparison if any hot path changed (Phase A, D)
-
----
-
-## 9. Open Design Questions
-
-These don't need answers now, but the Phase C agent should surface them:
-
-1. **CLI shape.** Is interactive mode a new subcommand
-   (`fractal-renderer interactive params.json`) or does it replace both
-   `explore` and a future `color-editor`? My default recommendation:
-   single `interactive` subcommand; `explore` becomes a deprecated alias.
-
-2. **Params file round-trip.** Should color edits in the GUI be saveable
-   back to the original JSON? What about fractal param edits? If yes, need
-   a "Save As" workflow.
-
-3. **Live-update architecture.** Per-frame texture upload vs. custom wgpu
-   callback. Benchmark-driven decision (Phase A spike).
-
-4. **Non-escape-time fractals** (Barnsley fern, pendulum): Phase D1's
-   "color without re-render" only works for fractals with a separable
-   compute/color pipeline. Others need full re-render on color change. Is
-   that UX acceptable, or should we cache their final-pixel buffers
-   differently?
-
-5. **Headless mode coexistence.** Phase C introduces an `interactive` CLI
-   entry; the headless `render` command is untouched. Confirm no shared
-   code paths break (likely safe since `Renderable` is already shared).
+- [ ] All CI green locally (fmt, clippy, test, bench --no-run).
+- [ ] Unit tests added for new pure-logic pieces (per §10.1).
+- [ ] Pixel-hash regression tests pass unchanged where applicable
+      (Phases 1, 2 especially).
+- [ ] Manual smoke-test on Windows native.
+- [ ] Manual smoke-test on WSL.
+- [ ] Manual smoke-test on native Linux (if available).
+- [ ] If a hot path changed: `cargo bench` comparison before/after.
+- [ ] If JSON schema changed: every example JSON re-loads and produces the
+      same image hash (or a documented and intended pixel difference).
+- [ ] Doc updates: this roadmap reflects what was actually shipped (move
+      in-progress phases to "done" or amend if scope shifted).
 
 ---
 
-## 10. Quick Start for a New Agent
+## 13. Open Questions for the Implementer
 
-If you're an agent picking up Phase A:
+These do not block any phase but should be decided as the relevant phase
+lands.
 
-1. Read `src/core/user_interface.rs` end-to-end — understand the existing
-   event loop and how `pixels` is used.
-2. Read `src/core/color_map_editor_ui.rs` end-to-end — this is your
-   reference for the `eframe::App` pattern in this codebase.
-3. Read `src/core/render_window.rs` to understand `PixelGrid::draw()` which
-   currently takes `&mut [u8]` from `pixels.frame_mut()`.
-4. Start with the spike from Phase A's "De-risk first" section.
-5. Implement the port in small commits; keep the old code compiling as
-   long as possible to allow side-by-side testing.
+1. **Variant slack at the type level.** Each fractal stores
+   `color: UnifiedColorMap` as the full enum but only ever uses one variant.
+   If this becomes painful in practice (e.g. lots of `match` arms doing
+   `_ => panic!`), consider introducing typed wrappers at the params level
+   (`BackgroundWithColorMap` as its own struct that `Into<UnifiedColorMap>`).
+   Default: live with the slack; revisit if it bites.
+2. **Active Newton tab on switch.** When the active tab changes, reset
+   keyframe selection. Recommended.
+3. **Reuse of `paint_gradient_bar`.** The current
+   [src/core/color_map_editor_ui.rs:215-241](../src/core/color_map_editor_ui.rs#L215-L241)
+   already implements an artifact-free gradient bar. Keep it; lift into
+   `src/core/interactive/editor.rs` rather than rewriting.
+4. **Color edits → adaptive regulator?** Whether to feed color edits into
+   `user_interaction = true`. Defer to Phase 7 measurement.
+5. **DDP basin coloring richness.** Today DDP collapses all non-zero basins
+   into one "background" bucket. Future work could expose per-basin colors,
+   which would require extending `UnifiedColorMap` with a richer DDP variant
+   (or adopting `MultiColorMap` for DDP). Out of scope for this roadmap.
 
-If you're picking up Phase B:
+---
 
-1. Confirm Phase A is on `main` (no `pixels` or direct `winit` deps).
-2. Follow §3.4's API shift table mechanically.
-3. Edition 2024 errors: fix them one by one, don't reformat preemptively.
+## 14. Quick Start for a New Agent
 
-If you're picking up Phase C or D:
-
-1. Confirm the previous phase is on `main`.
-2. Re-read §5's scope for your phase.
-3. Revisit §9's open questions and propose answers before writing code.
+1. Read this doc end-to-end.
+2. Read [src/core/user_interface.rs](../src/core/user_interface.rs) and
+   [src/core/color_map_editor_ui.rs](../src/core/color_map_editor_ui.rs)
+   to understand the two existing eframe apps you're unifying.
+3. Read [src/core/render_window.rs](../src/core/render_window.rs) to
+   understand `PixelGrid` and the existing background-render pattern.
+4. Read [src/fractals/quadratic_map.rs](../src/fractals/quadratic_map.rs),
+   [src/fractals/driven_damped_pendulum.rs](../src/fractals/driven_damped_pendulum.rs),
+   and [src/fractals/newtons_method.rs](../src/fractals/newtons_method.rs)
+   to understand the three different color-map representations you're
+   unifying.
+5. Confirm `cargo test` passes on `main`. Pick the next phase that hasn't
+   landed.
+6. Re-read §6's detail for that phase. Re-read §11 for risks specific to
+   that phase. Make a small first commit (e.g. just the `UnifiedColorMap`
+   enum definition + tests, before any params struct changes) to keep the
+   diff reviewable.
 
 Good luck.

--- a/docs/gui-unification-roadmap.md
+++ b/docs/gui-unification-roadmap.md
@@ -63,10 +63,15 @@ egui = "0.34"
 
 ### Two independent eframe apps share no infrastructure
 
-| Mode         | File                                                                                           | Status                                                       |
-| ------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Explore      | [src/core/user_interface.rs](../src/core/user_interface.rs)                                    | `eframe::App`; preview-only; full pan/zoom/save behavior     |
-| Color editor | [src/core/color_map_editor_ui.rs](../src/core/color_map_editor_ui.rs)                          | `eframe::App`; demo widgets only — does not affect renderer  |
+**Explore**
+
+- **File:** [src/core/user_interface.rs](../src/core/user_interface.rs)
+- **Status:** `eframe::App`; preview-only; full pan/zoom/save behavior
+
+**Color editor**
+
+- **File:** [src/core/color_map_editor_ui.rs](../src/core/color_map_editor_ui.rs)
+- **Status:** `eframe::App`; demo widgets only — does not affect renderer
 
 Both apps share [src/core/eframe_support.rs](../src/core/eframe_support.rs) for
 `wgpu` setup, but everything else is duplicated.
@@ -86,27 +91,32 @@ implement RenderWindow" — they are intentionally out of scope for `explore`.
 The three explorable fractal families today use structurally different color
 representations:
 
-| Fractal              | Representation                                                                              |
-| -------------------- | ------------------------------------------------------------------------------------------- |
-| Mandelbrot, Julia    | `ColorMapParams` = 1 gradient + 1 flat background ([src/fractals/quadratic_map.rs:19](../src/fractals/quadratic_map.rs#L19)) |
-| Driven-damped pendulum | No color params at all — hard-coded white/black in `render_point` ([src/fractals/driven_damped_pendulum.rs:38-44](../src/fractals/driven_damped_pendulum.rs#L38-L44)) |
-| Newton's method      | `CommonParams` with `boundary_set_color_rgb` + `cyclic_attractor_color_rgb` + `ColorMapSpec` enum (FullColorSpec or GrayscaleSpec) ([src/fractals/newtons_method.rs:204-266](../src/fractals/newtons_method.rs#L204-L266)) |
+**Mandelbrot, Julia**
 
-Unifying these is Phase 1.
+- **Representation:** `ColorMapParams` = 1 gradient + 1 flat background ([src/fractals/quadratic_map.rs:19](../src/fractals/quadratic_map.rs#L19))
+
+**Driven-damped pendulum**
+
+- **Representation:** No color params at all — hard-coded white/black in `render_point` ([src/fractals/driven_damped_pendulum.rs:38-44](../src/fractals/driven_damped_pendulum.rs#L38-L44))
+
+**Newton's method**
+
+- **Representation:** `CommonParams` with `boundary_set_color_rgb` + `cyclic_attractor_color_rgb` + `ColorMapSpec` enum (FullColorSpec or GrayscaleSpec) ([src/fractals/newtons_method.rs:204-266](../src/fractals/newtons_method.rs#L204-L266))
+  Unifying these is Phase 1.
 
 ---
 
 ## 3. Phase Roadmap Summary
 
-| Phase | Title                          | Blast radius                                          |
-| ----- | ------------------------------ | ----------------------------------------------------- |
-| 1     | Color-map data unification     | All fractal params + every example/test JSON file     |
-| 2     | Compute / color split          | `Renderable` trait + each fractal's render pipeline   |
-| 3     | Unified `FractalApp` shell     | New `src/core/interactive/` module; preview only      |
-| 4     | Color editor panel             | Editor widget + layout wiring                         |
-| 5     | CLI + cleanup + Space-as-save  | Delete legacy modules; extend snapshot behavior       |
-| 6     | Live color sync                | `PixelGrid` extended with re-colorize-only path       |
-| 7     | Polish                         | Contents TBD post-Phase-6 measurement                 |
+| Phase | Title                         | Blast radius                                        |
+| ----- | ----------------------------- | --------------------------------------------------- |
+| 1     | Color-map data unification    | All fractal params + every example/test JSON file   |
+| 2     | Compute / color split         | `Renderable` trait + each fractal's render pipeline |
+| 3     | Unified `FractalApp` shell    | New `src/core/interactive/` module; preview only    |
+| 4     | Color editor panel            | Editor widget + layout wiring                       |
+| 5     | CLI + cleanup + Space-as-save | Delete legacy modules; extend snapshot behavior     |
+| 6     | Live color sync               | `PixelGrid` extended with re-colorize-only path     |
+| 7     | Polish                        | Contents TBD post-Phase-6 measurement               |
 
 Phases 1 and 2 are independent pre-work — either order works, but Phase 1 is
 recommended first so Phase 2's `colorize` function can target `UnifiedColorMap`
@@ -219,7 +229,7 @@ pub type SmoothScalarField          = Vec<Vec<Option<f32>>>;
 pub type SmoothScalarWithIndexField = Vec<Vec<Option<(f32, usize)>>>;
 ```
 
-Names are descriptive (what the structure *is*), not fractal-named.
+Names are descriptive (what the structure _is_), not fractal-named.
 Newton's `boundary_set_color_rgb` is intentionally absent from `MultiColorMap`:
 it is dead code in the renderer ([src/fractals/newtons_method.rs:416-428](../src/fractals/newtons_method.rs#L416-L428)
 never reads it) and exists today only to define the "in-set" endpoint of the
@@ -295,11 +305,23 @@ enforces the pairing.
 
 ### 5.3 Per-fractal pairings
 
-| Concrete `ColorMap` type   | Concrete `Field` type            | Fractal                  | Colorization rule                                                       |
-| -------------------------- | -------------------------------- | ------------------------ | ----------------------------------------------------------------------- |
-| `ForegroundBackground`     | `BinaryBasinField`               | DDP                      | `Some(0)` → `foreground`; `Some(_)` or `None` → `background`            |
-| `BackgroundWithColorMap`   | `SmoothScalarField`              | Mandelbrot, Julia        | `None` → `background`; `Some(f)` → `color_map.lookup(f)`                |
-| `MultiColorMap`            | `SmoothScalarWithIndexField`     | Newton's method          | `None` → `cyclic_attractor`; `Some((f, k))` → `color_maps[k].lookup(f)` |
+**ForegroundBackground**
+
+- **Concrete Field type:** `BinaryBasinField`
+- **Fractal:** DDP
+- **Colorization rule:** `Some(0)` → `foreground`; `Some(_)` or `None` → `background`
+
+**BackgroundWithColorMap**
+
+- **Concrete Field type:** `SmoothScalarField`
+- **Fractal:** Mandelbrot, Julia
+- **Colorization rule:** `None` → `background`; `Some(f)` → `color_map.lookup(f)`
+
+**MultiColorMap**
+
+- **Concrete Field type:** `SmoothScalarWithIndexField`
+- **Fractal:** Newton's method
+- **Colorization rule:** `None` → `cyclic_attractor`; `Some((f, k))` → `color_maps[k].lookup(f)`
 
 Each fractal's params struct embeds its concrete `ColorMap` type directly
 (e.g. `MandelbrotParams` carries `pub color: BackgroundWithColorMap`).
@@ -387,7 +409,7 @@ accordingly. No GUI work, no trait changes (Phase 2 handles trait wiring).
   in this phase.
 - [src/fractals/quadratic_map.rs](../src/fractals/quadratic_map.rs) — replace
   `ColorMapParams.keyframes` and `background_color_rgb` with `pub color:
-  BackgroundWithColorMap`. The other `ColorMapParams` fields
+BackgroundWithColorMap`. The other `ColorMapParams` fields
   (`lookup_table_count`, `histogram_bin_count`, `histogram_sample_count`) are
   not color data and stay on `QuadraticMapParams` directly (or move into a
   sibling struct — implementer's choice).
@@ -517,7 +539,8 @@ on every panel — matches current explore mode and avoids border artifacts
 (§4.1).
 
 **Verification:** manual smoke-test all four fractal types on Windows native
-+ WSL.
+
+- WSL.
 
 ### Phase 4 — Color editor panel
 
@@ -569,7 +592,9 @@ copy**. The fractal preview is not affected by edits — that's Phase 6.
 │                                             │ ───────────────────  │
 │                                             │ [gradient bar]       │
 │                                             │ ───────────────────  │
+│                                             │                      │
 │                                             │ [color picker]       │
+│                                             │                      │
 └─────────────────────────────────────────────┴──────────────────────┘
 ```
 
@@ -656,7 +681,7 @@ re-colorize from it on every color edit. Re-colorize is pure pixel-level work
 **Editor cache transition:** the separate `editor_color_map: F::ColorMap` from
 Phase 4 becomes redundant. The editor now mutates `renderer.color_map_mut()`
 directly (still typed as `&mut F::ColorMap`, statically dispatched). The app
-retains only editor *selection* state (selected keyframe index, active Newton
+retains only editor _selection_ state (selected keyframe index, active Newton
 tab) — the data lives on the renderer.
 
 **Adaptive quality regulator interaction:** color edits trigger only
@@ -690,6 +715,7 @@ Contents to be defined post-Phase-6 measurement. Likely candidates:
 ## 7. Color Editor Widget Spec
 
 ### 7.1 Single-gradient editor (used by `BackgroundWithColorMap` and each
+
 `MultiColorMap` tab)
 
 **Read-only displays:**
@@ -702,7 +728,7 @@ Contents to be defined post-Phase-6 measurement. Likely candidates:
 **Mutable handles:**
 
 - Between each pair of adjacent keyframes: a `+` button and a `DragValue`
-  showing the *fraction* of the gradient occupied by that segment (the
+  showing the _fraction_ of the gradient occupied by that segment (the
   difference between the two adjacent keyframe positions).
 - Inline color picker (egui's `color_picker_color32`), permanently visible
   at the bottom of the panel.
@@ -724,7 +750,7 @@ Contents to be defined post-Phase-6 measurement. Likely candidates:
   user edits the new keyframe). The `+` button does not appear before the
   first keyframe or after the last.
 - **Edit a fraction `DragValue`** → that fraction adopts the new value; the
-  *other* fractions are scaled proportionally so the sum stays 1.0; the
+  _other_ fractions are scaled proportionally so the sum stays 1.0; the
   keyframe positions are recomputed from the resulting fractions. Each
   fraction is clamped to `[ε, 1.0]` (with `ε ≈ 0.005`) to prevent any
   segment from collapsing to zero width.
@@ -742,18 +768,18 @@ Contents to be defined post-Phase-6 measurement. Likely candidates:
 
 ### 7.3 Application keys (interactive mode)
 
-| Key                | Behavior                                                                         |
-| ------------------ | -------------------------------------------------------------------------------- |
-| Arrow keys         | Pan view (existing).                                                             |
-| W / S              | Zoom in / out (existing).                                                        |
-| A / D (with no W/S)| Fast zoom in / out (existing).                                                   |
-| R                  | Reset to initial view (existing).                                                |
-| Mouse left-click   | Recenter view on clicked point in the fractal preview (existing).                |
-| Space              | Save snapshot — see §8.                                                          |
-| Q                  | Exit application.                                                                |
-| Ctrl+C             | Exit application (terminal default).                                             |
-| Esc                | Clear keyframe selection. **No-op when no keyframe is selected.** Does not exit. |
-| Delete             | Remove selected keyframe (no-op for first/last).                                 |
+| Key                 | Behavior                                                                         |
+| ------------------- | -------------------------------------------------------------------------------- |
+| Arrow keys          | Pan view (existing).                                                             |
+| W / S               | Zoom in / out (existing).                                                        |
+| A / D (with no W/S) | Fast zoom in / out (existing).                                                   |
+| R                   | Reset to initial view (existing).                                                |
+| Mouse left-click    | Recenter view on clicked point in the fractal preview (existing).                |
+| Space               | Save snapshot — see §8.                                                          |
+| Q                   | Exit application.                                                                |
+| Ctrl+C              | Exit application (terminal default).                                             |
+| Esc                 | Clear keyframe selection. **No-op when no keyframe is selected.** Does not exit. |
+| Delete              | Remove selected keyframe (no-op for first/last).                                 |
 
 The Esc-as-quit binding present in today's [src/core/user_interface.rs:216](../src/core/user_interface.rs#L216)
 must be removed.
@@ -798,7 +824,7 @@ Idle ──Space pressed──► Saving ──save complete──► Idle
    user-specified quality, not whatever degraded state interactive use had
    pushed it to.
 3. **Sync color map.** Push the editor's current color map (which in Phase 6
-   *is* `renderer.color_map_mut()`; in Phase 5 was a separate
+   _is_ `renderer.color_map_mut()`; in Phase 5 was a separate
    `editor_color_map: F::ColorMap` cache) into the renderer's params for
    serialization.
 4. **Render to GUI.** Background thread runs `compute_field` (full quality)
@@ -817,7 +843,7 @@ Idle ──Space pressed──► Saving ──save complete──► Idle
 ### 8.3 Restorability invariant
 
 Calling `cargo run -- explore <saved.json>` on the file produced by step 5
-must restore the GUI to *exactly* the state it was in when Space was pressed:
+must restore the GUI to _exactly_ the state it was in when Space was pressed:
 the same view bounds, the same color map (including any edits), the same
 render quality, the same fractal type. The pixel hash of the rendered preview
 should match the saved PNG.
@@ -845,12 +871,12 @@ what's written to disk, and what re-loads next time.
 
 ### 9.2 Render trigger matrix
 
-| Event                          | What runs                                  | Quality           |
-| ------------------------------ | ------------------------------------------ | ----------------- |
-| Pan / zoom / click             | `compute_field` + `colorize`               | Adaptive          |
-| Color edit (Phase 6+)          | `colorize` only (uses cached field)        | Full              |
-| Space pressed                  | `compute_field` + `colorize`               | Forced to full    |
-| Idle (no interaction)          | Adaptive regulator may trigger upgrade     | Climbing → full   |
+| Event                 | What runs                              | Quality         |
+| --------------------- | -------------------------------------- | --------------- |
+| Pan / zoom / click    | `compute_field` + `colorize`           | Adaptive        |
+| Color edit (Phase 6+) | `colorize` only (uses cached field)    | Full            |
+| Space pressed         | `compute_field` + `colorize`           | Forced to full  |
+| Idle (no interaction) | Adaptive regulator may trigger upgrade | Climbing → full |
 
 ### 9.3 Adaptive regulator
 
@@ -939,21 +965,45 @@ WSL2/XWayland, native Linux if available.
 
 ## 11. Risks & De-risk
 
-| Risk                                                                | Phase | Mitigation                                                                                                |
-| ------------------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------- |
-| JSON migration misses a file                                        | 1     | `tests/example_parameter_validation_tests.rs` glob covers all JSONs; CI catches missed migrations.        |
-| Schema migration changes pixel hashes                               | 1     | Pixel-hash regression tests gate the PR; if hashes change, the migration changed semantics — bug.         |
-| Compute/color split breaks pixel hashes                             | 2     | Pure refactor; pixel-hash tests are the gate.                                                             |
-| `colorize_into` too slow at 4K to be live                           | 6     | Benchmark over a representative `SmoothScalarField` at 4K early in Phase 6. Falls back to Phase 7 work.   |
-| Newton tab count drifts from `color_maps.len()`                     | 4, 6  | Tab strip is a pure view of `color_maps.iter().enumerate()`; no separately stored count.                  |
-| Editor state desync after `MultiColorMap` tab switch                | 4, 6  | Selection state resets on tab change (specified in §7.2).                                                 |
-| Adaptive regulator behaves badly during color editing               | 6, 7  | Regulator self-tunes; if behavior is wrong, Phase 7 adjusts whether color edits feed `user_interaction`.  |
+**JSON migration misses a file**
+
+- **Phase:** 1
+- **Mitigation:** `tests/example_parameter_validation_tests.rs` glob covers all JSONs; CI catches missed migrations.
+
+**Schema migration changes pixel hashes**
+
+- **Phase:** 1
+- **Mitigation:** Pixel-hash regression tests gate the PR; if hashes change, the migration changed semantics — bug.
+
+**Compute/color split breaks pixel hashes**
+
+- **Phase:** 2
+- **Mitigation:** Pure refactor; pixel-hash tests are the gate.
+
+**`colorize_into` too slow at 4K to be live**
+
+- **Phase:** 6
+- **Mitigation:** Benchmark over a representative `SmoothScalarField` at 4K early in Phase 6. Falls back to Phase 7 work.
+
+**Newton tab count drifts from `color_maps.len()`**
+
+- **Phase:** 4, 6
+- **Mitigation:** Tab strip is a pure view of `color_maps.iter().enumerate()`; no separately stored count.
+
+**Editor state desync after `MultiColorMap` tab switch**
+
+- **Phase:** 4, 6
+- **Mitigation:** Selection state resets on tab change (specified in §7.2).
+
+**Adaptive regulator behaves badly during color editing**
+
+- **Phase:** 6, 7
+- **Mitigation:** Regulator self-tunes; if behavior is wrong, Phase 7 adjusts whether color edits feed `user_interaction`.
 
 Variant-mismatch is intentionally not on this list: the typed-pairing design
 (§5) makes it unrepresentable. The only way for a wrong-shape color map to
 reach the renderer is via malformed JSON, which fails serde deserialization
-before any fractal object is constructed. The `_ => panic!` arm that an
-earlier design relied on does not exist.
+before any fractal object is constructed.
 
 ---
 

--- a/docs/gui-unification-roadmap.md
+++ b/docs/gui-unification-roadmap.md
@@ -1,0 +1,544 @@
+# GUI Unification Roadmap
+
+This document describes the multi-phase plan to consolidate the project onto a
+single cross-platform GUI architecture built on `eframe`/`egui`, on Rust 2024
+edition, while eliminating legacy `pixels` + hand-rolled `winit` code paths.
+
+**Audience:** a new agent or contributor picking up the GUI work. This doc is
+self-contained — no prior conversation context is needed.
+
+---
+
+## 1. End State Vision
+
+The binary ships with exactly two modes:
+
+1. **Headless render mode** (CLI: `fractal-renderer render ...`) — unchanged
+   from today. Writes images to disk based on a params JSON file. No GUI.
+2. **Interactive mode** (CLI: `fractal-renderer interactive ...` or similar) —
+   a single unified GUI window that combines:
+   - Fractal preview (pan/zoom/click, as `explore` mode does today)
+   - Color map editor (gradient bar, keyframe editing, as the color editor does
+     today)
+   - Parameter inspector (view/edit fractal params live)
+
+The interactive mode is built entirely on `eframe` (egui's official framework),
+with a **background render thread** feeding a `TextureHandle` for live updates.
+
+**What disappears:**
+
+- `pixels` crate and everything that depends on it
+- Direct `winit` usage (eframe owns the event loop)
+- The `cli/explore.rs` + `core/user_interface.rs` hand-rolled event loop
+
+---
+
+## 2. Current State (as of branch landing this roadmap)
+
+### What exists today
+
+Two independent GUI code paths share no infrastructure:
+
+| Mode         | File                                           | Framework                                | Dependencies           |
+| ------------ | ---------------------------------------------- | ---------------------------------------- | ---------------------- |
+| Explore mode | `src/core/user_interface.rs` (~365 lines)      | hand-rolled `winit 0.28` + `pixels 0.13` | no egui                |
+| Color editor | `src/core/color_map_editor_ui.rs` (~310 lines) | `eframe 0.22` (`egui 0.22`)              | no direct winit/pixels |
+
+### Recent work landed on the `color-gui/...` branch
+
+1. Migrated color editor from hand-rolled `pixels` + `egui-wgpu` + `egui-winit`
+   to `eframe 0.22`. Shrank the file ~185 lines.
+2. Set `panel_fill = BLACK`, `bg_stroke = NONE`, `show_separator_line(false)`
+   to eliminate egui's default separator lines.
+3. Overrode panel frames with `Frame::none().fill(BLACK)` to eliminate
+   sub-pixel gap artifacts at panel boundaries.
+4. Replaced `SidePanel::exact_width` with `default_width` + `width_range` so
+   the editor pane is actually resizable by dragging.
+5. Replaced the gradient bar's `line_segment` loop with `rect_filled`
+   (contiguous rectangles) to eliminate 1-logical-pixel stroke artifacts at
+   fractional DPI.
+6. Added defensive `ctx.request_repaint()` at the end of `App::update()` to
+   self-correct from silently-dropped resize events on WSL/XWayland.
+
+### Known bugs that remain (platform-level, not fixable on eframe 0.22)
+
+| Bug                                              | Platform             | Cause                                                                                 | Fix                              |
+| ------------------------------------------------ | -------------------- | ------------------------------------------------------------------------------------- | -------------------------------- |
+| Window can't be dragged between monitors         | Windows (mixed DPI)  | `winit 0.28` `WM_DPICHANGED` feedback loop                                            | winit 0.29+ (via eframe 0.24+)   |
+| Resize events silently dropped at fractional DPI | WSL/XWayland         | `winit 0.28` bug on Wayland scale changes                                             | winit 0.29.9+ (via eframe 0.24+) |
+| No resize handles                                | WSL (some X servers) | X11 forwarding with no window manager — eframe already requests decorations correctly | environment-level (run a WM)     |
+
+---
+
+## 3. Hard Constraints
+
+These are non-obvious gotchas discovered during the color editor migration.
+Any future work must account for them.
+
+### 3.1 The `wgpu_core` linker conflict
+
+`wgpu_core` exports `#[no_mangle]` C symbols. Two versions of `wgpu_core` in
+the same binary → **linker error** (duplicate symbols), not just a warning.
+
+This means: **all crates that transitively depend on wgpu must share a
+version.** Currently:
+
+- `pixels 0.13` → `wgpu 0.16`
+- `eframe 0.22` → `wgpu 0.16` ✓ (coincidentally matches)
+- `eframe 0.24, 0.25, 0.26, 0.27` → `wgpu 0.19`
+- `eframe 0.28` → `wgpu 0.20`
+- `eframe 0.29+` → `wgpu 0.20+`
+
+- `pixels 0.13` → `wgpu 0.16`
+- `pixels 0.14` → `wgpu 0.17`
+- `pixels 0.15` → `wgpu 0.19`
+- `pixels 0.16` → `wgpu 0.29`
+
+**Implication:** as long as the explore mode uses `pixels`, it constrains
+`eframe` to a compatible version. The only way to upgrade `eframe` past 0.22
+without dep-tree conflicts is to **remove `pixels` first** (by porting explore
+mode to eframe).
+
+### 3.2 The `raw-window-handle` conflict
+
+`pixels 0.14+` uses `raw-window-handle 0.6`. `winit 0.28` uses
+`raw-window-handle 0.5`. These version numbers are mutually incompatible at
+the trait level — you cannot pass a `&winit::Window` (RWH 0.5) to a
+`pixels::Pixels::new` (RWH 0.6).
+
+**Implication:** `pixels` and `winit` versions are coupled too. You can't mix
+`pixels 0.14+` with `winit 0.28`.
+
+### 3.3 Rust edition requirements
+
+- `eframe 0.32+` requires Rust edition 2024.
+- Current `Cargo.toml` declares `edition = "2018"`.
+- Edition 2024 has stricter rules (disjoint closure captures, temporary
+  lifetimes, new reserved keywords like `gen`). A clean codebase usually needs
+  only a handful of fixes, but it's an unknown ripple risk.
+
+**Implication:** jumping to the latest eframe (0.34) requires a Rust edition
+bump as a prerequisite. eframe 0.27 is the highest version that still compiles
+on edition 2018/2021.
+
+### 3.4 eframe API shifts between 0.22 and latest
+
+When upgrading, expect these mechanical changes:
+
+| 0.22                                   | 0.24+                                                         | 0.28+                                                         |
+| -------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------- |
+| `initial_window_size: Some(vec2(w,h))` | `viewport: ViewportBuilder::default().with_inner_size([w,h])` | same                                                          |
+| `frame.close()`                        | `ctx.send_viewport_cmd(ViewportCommand::Close)`               | same                                                          |
+| `Box::new(\|cc\| Box::new(App))`       | same                                                          | `Box::new(\|cc\| Ok(Box::new(App)))`                          |
+| `egui::Image::new(&tex, size)`         | `Image::new(&tex).fit_to_exact_size(size)`                    | same                                                          |
+| `egui::style::Margin`                  | `egui::Margin`                                                | same                                                          |
+| `DragValue::clamp_range`               | deprecated → `.range()`                                       | same                                                          |
+| `App::update` method                   | same                                                          | same (but `App::ui` preferred in 0.34)                        |
+| Linux needs features                   | `eframe = { features = ["wgpu"] }`                            | `eframe = { features = ["wgpu", "x11", "wayland"] }` (v0.30+) |
+
+---
+
+## 4. Cross-Platform Learnings
+
+Distilled from cross-platform testing on Windows native, WSL2/XWayland, and
+code-level investigation of winit/egui/pixels source.
+
+### 4.1 Border/line artifacts at panel boundaries
+
+**Symptom:** thin white or gray lines appear between `SidePanel` and
+`CentralPanel` when the window is maximized or fullscreen, especially at
+fractional DPI.
+
+**Root causes (multiple):**
+
+1. Default `SidePanel` draws a 1px separator line via
+   `visuals.widgets.noninteractive.bg_stroke` (gray(60) in dark theme).
+   → Fix: `show_separator_line(false)` + set `bg_stroke = Stroke::NONE`.
+2. Default `panel_fill = gray(27)` against black background shows 1px gaps at
+   panel seams due to `rect.shrink(1.0)` in egui's panel drawing code.
+   → Fix: set `panel_fill = Color32::BLACK` and override each panel with
+   `Frame::none().fill(Color32::BLACK)`.
+3. Manual 1-logical-pixel strokes at fractional x-positions anti-alias across
+   two physical pixels (e.g. `paint_gradient_bar` using `line_segment`).
+   → Fix: use `painter.rect_filled` with contiguous rectangles instead.
+
+See `src/core/color_map_editor_ui.rs` for the current implementation that
+applies all three fixes.
+
+### 4.2 Resize event drops on WSL/XWayland
+
+**Symptom:** window appears not to resize at all, or content stops updating
+when the user drags the window edge.
+
+**Root cause:** `winit 0.28` on Wayland can drop resize events when the scale
+factor changes. Fixed in `winit 0.29.9`.
+
+**Mitigation on old winit:** `ctx.request_repaint()` at the end of `update()`
+forces eframe to re-poll surface size every frame, self-correcting on the
+next paint cycle. Cost is modest since egui still short-circuits painting
+when nothing changed.
+
+**Real fix:** upgrade eframe to 0.24+ (pulls in winit 0.29+).
+
+### 4.3 Windows multi-monitor drag stuck
+
+**Symptom:** dragging a window between monitors with different DPI scales
+causes the window to stutter and snap back to the original monitor, or get
+"stuck" at the boundary.
+
+**Root cause:** `winit 0.28`'s `WM_DPICHANGED` handler repositions the window
+during drag, which can trigger another `WM_DPICHANGED` event, creating a
+feedback loop. The pixel-by-pixel nudge logic in
+`winit/src/platform_impl/windows/event_loop.rs` lines ~2248-2259 is bounded
+but still visible to the user.
+
+**Mitigation:** none available on winit 0.28. Fixed in winit 0.29+.
+
+### 4.4 No resize handles on WSL
+
+**Symptom:** the window has no visible resize borders; can't drag edges.
+
+**Root cause:** environmental, not a code bug. eframe correctly passes
+`decorated(true)` and `resizable(true)` to winit. On X11, window decorations
+(title bar, resize borders) are provided by the **window manager** — WSL's X
+server may not provide one.
+
+**Mitigation:** run a window manager (`openbox`, `fluxbox`) alongside the X
+server. Not fixable in-repo.
+
+### 4.5 egui panel width locking
+
+**Gotcha:** `SidePanel::exact_width(w)` does NOT just set the initial width —
+it clamps `width_range` to `w..=w`, making the panel non-resizable even
+though the resize drag handle still renders (just does nothing on drag).
+
+**Fix pattern:** use `default_width(w).width_range(min..=max)` instead.
+
+---
+
+## 5. Roadmap
+
+Four phases, each a self-contained PR. Each phase is bisectable and
+independently revertible.
+
+### Phase A: Port explore mode to eframe (on eframe 0.22)
+
+**Goal:** unify the GUI framework. Remove `pixels` from the dep tree. Leave
+everything else stable.
+
+**Why eframe 0.22 specifically?** To minimize moving parts. The explore
+mode's _migration_ is a big change; combining it with an eframe version bump
+would make a bad PR. Do the version bump in Phase B, after the framework is
+unified.
+
+**Scope:**
+
+- Rewrite `src/core/user_interface.rs` as an `eframe::App` implementation.
+- Convert the CPU fractal buffer to `egui::ColorImage` → `TextureHandle`
+  each frame the fractal changes.
+- Replace `RawInputState` with `ctx.input()`.
+- Replace `pixels.window_pos_to_pixel(...)` with math derived from
+  `ui.min_rect()` and the fractal image aspect ratio.
+- Delete `pixels` dep from `Cargo.toml`.
+- Delete direct `winit` dep from `Cargo.toml` (eframe re-exports what's
+  needed).
+- Keep the background-ish render model: `PixelGrid` / `RenderWindow` in
+  `src/core/render_window.rs` probably need small signature changes
+  (e.g. accept `&mut ColorImage` or a raw `&mut [u8]` instead of
+  `pixels.frame_mut()`).
+
+**Risks:**
+
+- `TextureHandle::set()` performance at 60+ Hz during pan/zoom. The explore
+  mode re-renders continuously during interaction. Must benchmark early.
+- Input semantics differ: `winit` keyboard events vs. `egui::Key`. Key
+  mappings need a translation layer (or just use egui keys directly).
+- Mouse-click-to-center behavior: needs to convert pointer position from
+  egui `Pos2` in the fractal image's rect back to fractal space.
+
+**De-risk first:**
+
+- Spike: measure `TextureHandle::set(ColorImage)` + `egui::Image` render cost
+  at 1920×1080, 100 Hz. If it's over 3ms/frame on target hardware, redesign
+  (e.g. use `egui_wgpu::CallbackTrait` for a custom wgpu render pass that
+  reuses an existing GPU texture).
+
+**Expected outcome:**
+
+- Explore mode works identically, but now cross-platform (inherits eframe's
+  correct DPI/resize/multi-monitor handling — though still on winit 0.28's
+  bugs until Phase B).
+- Single Cargo.toml has just `eframe` + `egui` for GUI; no `pixels`, no
+  direct `winit`.
+- Both GUIs share the eframe App trait pattern.
+
+### Phase B: Modernize the stack (edition 2024 + eframe 0.34)
+
+**Prerequisite:** Phase A complete (no pixels/winit dep conflicts).
+
+**Scope:**
+
+- `Cargo.toml`: `edition = "2018"` → `edition = "2024"`.
+- Bump `eframe = "0.22"` → `"0.34"` and `egui = "0.22"` → `"0.34"`.
+- Fix the mechanical API shifts listed in §3.4.
+- Fix any Rust 2024 edition issues surfaced by `cargo check`:
+  - Disjoint closure captures may require explicit `&` or `&mut` in
+    closures.
+  - New reserved keywords (`gen`, `try`) — unlikely to affect this codebase.
+  - Temporary lifetime rule tightening — may need rebinding in a few
+    places.
+- Verify CI is green on all checks (`cargo fmt`, `cargo clippy -D warnings`,
+  `cargo test`, `cargo bench --no-run`).
+- Update MSRV in CI config if relevant.
+
+**Expected outcome:**
+
+- Fully modern Rust + eframe stack.
+- WSL resize-event drops and Windows multi-monitor-drag bugs fixed (via
+  winit 0.29+).
+- Latest egui widget set available for Phase C.
+
+**Risks:**
+
+- Edition 2024 ripple fixes could touch unrelated files (fractals modules,
+  core modules). Allot time for discovery.
+- egui 0.34 may have renamed or restructured widgets we use (especially
+  `egui::color_picker`, `Image`, `Slider` step/clamp APIs). Each needs
+  individual verification.
+
+### Phase C: Merge into a unified `FractalApp`
+
+**Prerequisite:** Phase B complete.
+
+**Goal:** one `eframe::App` implementation serves both interactive
+workflows.
+
+**Design to settle (not yet decided):**
+
+- **Layout:** likely a central fractal preview with docked panels:
+  - Right panel: color map editor (expandable)
+  - Left panel or top bar: fractal parameters (kind, iterations, bounds,
+    etc.)
+  - Bottom status: coordinates under cursor, render progress
+- **State model:** a single `FractalAppState` struct holding:
+  - Current `FractalParams` (the JSON type)
+  - Latest rendered `Vec<Vec<Rgb<u8>>>` buffer + its resolution
+  - `dirty: bool` flag per subsystem (view, params, colors)
+  - `egui::TextureHandle` for the preview
+- **Threading model:** background thread owns the render pipeline. UI thread
+  sends commands (center, zoom, params-change) via channel; background
+  thread posts completed buffers back via channel or shared
+  `Arc<Mutex<Option<Buffer>>>`.
+- **Redraw signaling:** `ctx.request_repaint()` from the UI side when input
+  changes; background thread calls `ctx.request_repaint()` after posting a
+  new buffer.
+
+**Scope:**
+
+- Move `explore` and `color_editor_ui` logic into a new
+  `src/core/interactive/` module with submodules for panels.
+- Wire up a single CLI subcommand (`interactive`) that takes a params JSON
+  file and opens the unified GUI.
+- Delete `src/cli/explore.rs` or keep it as a thin wrapper that calls the
+  new interactive entry point with explore-focused defaults.
+- Delete or quarantine the old `color_map_editor_ui.rs` once everything is
+  in the new module.
+
+### Phase D: Live color adjustment
+
+**Prerequisite:** Phase C complete.
+
+**Two sub-phases:**
+
+#### D1. Color adjustments without re-rendering the fractal
+
+Key insight: for escape-time fractals (Mandelbrot, Julia), the _histogram_
+or _escape count grid_ doesn't depend on the color map — only the final
+pixel coloring does. If we cache the escape-count grid, we can re-color
+instantly on a palette change.
+
+**Scope:**
+
+- Refactor `Renderable` (or add a parallel trait) so the compute and color
+  phases are separable:
+  - `compute_escape_grid() -> EscapeGrid`
+  - `color_grid(grid: &EscapeGrid, color_map: &ColorMap) -> ColorImage`
+- Cache the `EscapeGrid` in the app state; re-color on any color edit.
+- The gradient bar editing in the color panel → immediately re-colors the
+  preview (target: <1 frame latency).
+
+**What fractals this works for:** Mandelbrot, Julia, Newton's. Not
+Barnsley fern (no escape count, it's an IFS), not pendulum (phase
+portrait). Those need full re-render on color change — acceptable because
+they're not the common color-editing case.
+
+#### D2. Full dynamic parameter adjustment
+
+Backend param changes (iteration cap, view bounds, fractal kind) trigger a
+full re-render in the background thread. UI stays responsive with:
+
+- Debounce param changes by ~100ms to batch rapid slider edits.
+- Render at reduced resolution first (1/4 res), upgrade to full res when
+  interaction idles for ~500ms.
+- Cancellation: if a new render is requested while one is in flight, abort
+  the in-flight render (check a `stop_flag: Arc<AtomicBool>` in the
+  fractal hot loop).
+
+---
+
+## 6. Architecture & File Map
+
+### Files central to the GUI (current state)
+
+| File                              | Role                               | Phase that touches it                            |
+| --------------------------------- | ---------------------------------- | ------------------------------------------------ |
+| `src/core/color_map_editor_ui.rs` | Color editor `eframe::App`         | A (port reference), C (merge)                    |
+| `src/core/user_interface.rs`      | Explore mode event loop            | A (rewrite), C (delete or absorb)                |
+| `src/core/render_window.rs`       | `PixelGrid`/`RenderWindow` helpers | A (minor signature changes)                      |
+| `src/cli/explore.rs`              | Thin CLI wrapper                   | A (no change), C (delete or wrap)                |
+| `src/core/view_control.rs`        | Pan/zoom math                      | C (reuse)                                        |
+| `src/core/color_map.rs`           | Color interpolation                | D1 (reuse for re-coloring)                       |
+| `src/core/image_utils.rs`         | `Renderable` trait                 | D1 (split compute/color)                         |
+| `examples/common/mod.rs`          | Calls `run_color_editor`           | A, C (update call)                               |
+| `Cargo.toml`                      | Deps                               | A (remove pixels/winit), B (bump eframe/edition) |
+
+### Key trait: `Renderable`
+
+Defined in `src/core/image_utils.rs`. Currently:
+
+```rust
+pub trait Renderable {
+    fn render_to_buffer(&self, buffer: &mut Vec<Vec<image::Rgb<u8>>>);
+}
+```
+
+All fractal modules (`src/fractals/*.rs`) implement this. Phase D1 will
+likely split this into compute + color phases.
+
+---
+
+## 7. Dependency Version Matrix
+
+### Current (as of this doc's landing branch)
+
+```toml
+eframe = { version = "0.22", default-features = false, features = ["wgpu"] }
+egui = "0.22"
+pixels = "0.13"
+winit = "0.28"
+```
+
+Rust edition: **2018**.
+
+### Target after Phase A
+
+```toml
+eframe = { version = "0.22", default-features = false, features = ["wgpu"] }
+egui = "0.22"
+# pixels and winit removed entirely
+```
+
+### Target after Phase B
+
+```toml
+eframe = { version = "0.34", default-features = false, features = ["wgpu", "x11", "wayland"] }
+egui = "0.34"
+```
+
+Rust edition: **2024**.
+
+---
+
+## 8. Working Practices for This Roadmap
+
+### CI checks (from `AGENTS.md`/`CLAUDE.md`)
+
+Before every commit:
+
+```bash
+cargo fmt
+cargo clippy -- -D warnings
+cargo test
+cargo bench --no-run
+```
+
+Pre-commit hooks in `.claude/settings.json` enforce steps 1–4 automatically
+when committing via Claude Code.
+
+### Branch / commit conventions
+
+- Branches: `feature/description`, `fix/description`, `perf/description`
+- Commits: conventional (`feat:`, `fix:`, `perf:`, `refactor:`, `test:`,
+  `docs:`, `chore:`) OR imperative short titles
+- One logical change per commit
+- Include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` for
+  AI-assisted commits
+- Never push or open PRs without explicit user confirmation
+
+### Per-phase PR checklist
+
+- [ ] All CI green locally
+- [ ] Manual smoke test: `cargo run --example color-gui-demo` (Phase A–B)
+- [ ] Manual smoke test: the interactive binary on Windows native
+- [ ] Manual smoke test: the interactive binary on WSL
+- [ ] Manual smoke test: the interactive binary on native Linux (if
+      available)
+- [ ] Benchmark comparison if any hot path changed (Phase A, D)
+
+---
+
+## 9. Open Design Questions
+
+These don't need answers now, but the Phase C agent should surface them:
+
+1. **CLI shape.** Is interactive mode a new subcommand
+   (`fractal-renderer interactive params.json`) or does it replace both
+   `explore` and a future `color-editor`? My default recommendation:
+   single `interactive` subcommand; `explore` becomes a deprecated alias.
+
+2. **Params file round-trip.** Should color edits in the GUI be saveable
+   back to the original JSON? What about fractal param edits? If yes, need
+   a "Save As" workflow.
+
+3. **Live-update architecture.** Per-frame texture upload vs. custom wgpu
+   callback. Benchmark-driven decision (Phase A spike).
+
+4. **Non-escape-time fractals** (Barnsley fern, pendulum): Phase D1's
+   "color without re-render" only works for fractals with a separable
+   compute/color pipeline. Others need full re-render on color change. Is
+   that UX acceptable, or should we cache their final-pixel buffers
+   differently?
+
+5. **Headless mode coexistence.** Phase C introduces an `interactive` CLI
+   entry; the headless `render` command is untouched. Confirm no shared
+   code paths break (likely safe since `Renderable` is already shared).
+
+---
+
+## 10. Quick Start for a New Agent
+
+If you're an agent picking up Phase A:
+
+1. Read `src/core/user_interface.rs` end-to-end — understand the existing
+   event loop and how `pixels` is used.
+2. Read `src/core/color_map_editor_ui.rs` end-to-end — this is your
+   reference for the `eframe::App` pattern in this codebase.
+3. Read `src/core/render_window.rs` to understand `PixelGrid::draw()` which
+   currently takes `&mut [u8]` from `pixels.frame_mut()`.
+4. Start with the spike from Phase A's "De-risk first" section.
+5. Implement the port in small commits; keep the old code compiling as
+   long as possible to allow side-by-side testing.
+
+If you're picking up Phase B:
+
+1. Confirm Phase A is on `main` (no `pixels` or direct `winit` deps).
+2. Follow §3.4's API shift table mechanically.
+3. Edition 2024 errors: fix them one by one, don't reformat preemptively.
+
+If you're picking up Phase C or D:
+
+1. Confirm the previous phase is on `main`.
+2. Re-read §5's scope for your phase.
+3. Revisit §9's open questions and propose answers before writing code.
+
+Good luck.

--- a/docs/gui-unification-roadmap.md
+++ b/docs/gui-unification-roadmap.md
@@ -79,7 +79,9 @@ Both apps share [src/core/eframe_support.rs](../src/core/eframe_support.rs) for
 ### CLI
 
 [src/cli/args.rs](../src/cli/args.rs) defines three subcommands: `Render`,
-`Explore`, `ColorSwatch`. The `Explore` subcommand dispatches in
+`Explore`, `ColorSwatch`. This roadmap focuses primarily on modifications to
+`Explore`, while preserving functionality of `Render`. The `ColorSwatch` mode
+will be removed. The `Explore` subcommand dispatches in
 [src/cli/explore.rs](../src/cli/explore.rs) on the `FractalParams` variant:
 Mandelbrot/Julia/DDP go through generic `PixelGrid<F>`; Newton has its own
 explore path in [src/fractals/newtons_method.rs:461](../src/fractals/newtons_method.rs#L461).
@@ -408,8 +410,8 @@ accordingly. No GUI work, no trait changes (Phase 2 handles trait wiring).
   enum and `From` impls (per §5.4); skip if no caller materializes for them
   in this phase.
 - [src/fractals/quadratic_map.rs](../src/fractals/quadratic_map.rs) — replace
-  `ColorMapParams.keyframes` and `background_color_rgb` with `pub color:
-BackgroundWithColorMap`. The other `ColorMapParams` fields
+  `ColorMapParams.keyframes` and `background_color_rgb` with `pub color: BackgroundWithColorMap`.
+  The other `ColorMapParams` fields
   (`lookup_table_count`, `histogram_bin_count`, `histogram_sample_count`) are
   not color data and stay on `QuadraticMapParams` directly (or move into a
   sibling struct — implementer's choice).
@@ -538,9 +540,7 @@ in tree at this phase to keep diffs reviewable; it gets deleted in Phase 5.
 on every panel — matches current explore mode and avoids border artifacts
 (§4.1).
 
-**Verification:** manual smoke-test all four fractal types on Windows native
-
-- WSL.
+**Verification:** manual smoke-test all four fractal types on various platforms.
 
 ### Phase 4 — Color editor panel
 
@@ -694,9 +694,9 @@ compute time, so neither choice is structurally wrong.
 
 **Verification:** manual interactive testing — drag fraction sliders, click
 keyframe colors, verify the preview updates within a frame or two. Benchmark
-`colorize` over a representative `SmoothScalar` field at 1920×1080 and 4K to
-confirm it stays under one frame at 60Hz; if not, Phase 7 must include
-optimization or downscaling for the live path.
+`colorize` over a representative `SmoothScalar` field at 1920×1080 to
+confirm it stays under one frame at 24Hz; if not, Phase 7 must include
+tweaks to the adaptive quality scaling to make the UI feel smooth.
 
 ### Phase 7 — Polish
 
@@ -752,7 +752,7 @@ Contents to be defined post-Phase-6 measurement. Likely candidates:
 - **Edit a fraction `DragValue`** → that fraction adopts the new value; the
   _other_ fractions are scaled proportionally so the sum stays 1.0; the
   keyframe positions are recomputed from the resulting fractions. Each
-  fraction is clamped to `[ε, 1.0]` (with `ε ≈ 0.005`) to prevent any
+  fraction is clamped to `[ε, 1.0]` (with `ε ≈ 0.001`) to prevent any
   segment from collapsing to zero width.
 
 ### 7.2 Per-variant layout
@@ -773,7 +773,7 @@ Contents to be defined post-Phase-6 measurement. Likely candidates:
 | Arrow keys          | Pan view (existing).                                                             |
 | W / S               | Zoom in / out (existing).                                                        |
 | A / D (with no W/S) | Fast zoom in / out (existing).                                                   |
-| R                   | Reset to initial view (existing).                                                |
+| R                   | Reset to initial view (existing) and color map (new)                             |
 | Mouse left-click    | Recenter view on clicked point in the fractal preview (existing).                |
 | Space               | Save snapshot — see §8.                                                          |
 | Q                   | Exit application.                                                                |
@@ -799,7 +799,7 @@ must be removed.
 
 Pressing Space initiates a deliberate "publish this exact state" action.
 Unlike today's fire-and-forget snapshot, the new flow is gated on a
-full-quality render and locks input until complete.
+full-quality render and locks input (with user feedback) until complete.
 
 ### 8.1 State machine
 
@@ -822,7 +822,8 @@ Idle ──Space pressed──► Saving ──save complete──► Idle
    `AdaptiveOptimizationRegulator` so the next render uses
    `speed_optimization_level = 0.0`. The field will be computed at full
    user-specified quality, not whatever degraded state interactive use had
-   pushed it to.
+   pushed it to. Consider caching the current value of the quality so that it
+   can immediately be restored on the next user interaction to enable quick response.
 3. **Sync color map.** Push the editor's current color map (which in Phase 6
    _is_ `renderer.color_map_mut()`; in Phase 5 was a separate
    `editor_color_map: F::ColorMap` cache) into the renderer's params for
@@ -845,7 +846,7 @@ Idle ──Space pressed──► Saving ──save complete──► Idle
 Calling `cargo run -- explore <saved.json>` on the file produced by step 5
 must restore the GUI to _exactly_ the state it was in when Space was pressed:
 the same view bounds, the same color map (including any edits), the same
-render quality, the same fractal type. The pixel hash of the rendered preview
+render quality parameters, the same fractal type. The pixel hash of the rendered preview
 should match the saved PNG.
 
 ### 8.4 Comparison to current behavior
@@ -874,7 +875,7 @@ what's written to disk, and what re-loads next time.
 | Event                 | What runs                              | Quality         |
 | --------------------- | -------------------------------------- | --------------- |
 | Pan / zoom / click    | `compute_field` + `colorize`           | Adaptive        |
-| Color edit (Phase 6+) | `colorize` only (uses cached field)    | Full            |
+| Color edit (Phase 6+) | `colorize` only (uses cached field)    | (Cached Field)  |
 | Space pressed         | `compute_field` + `colorize`           | Forced to full  |
 | Idle (no interaction) | Adaptive regulator may trigger upgrade | Climbing → full |
 
@@ -949,7 +950,7 @@ but may be added later if a particular bug class becomes recurring.
 ### 10.2 What to manually smoke-test (mandatory each phase)
 
 Per the per-phase PR checklist (§12). Same matrix as today: Windows native,
-WSL2/XWayland, native Linux if available.
+WSL2/XWayland, native Linux, mac.
 
 ### 10.3 What to leave for later
 
@@ -980,10 +981,10 @@ WSL2/XWayland, native Linux if available.
 - **Phase:** 2
 - **Mitigation:** Pure refactor; pixel-hash tests are the gate.
 
-**`colorize_into` too slow at 4K to be live**
+**`colorize_into` too slow at 2k to be live**
 
 - **Phase:** 6
-- **Mitigation:** Benchmark over a representative `SmoothScalarField` at 4K early in Phase 6. Falls back to Phase 7 work.
+- **Mitigation:** Benchmark over a representative `SmoothScalarField` at 2K early in Phase 6. Falls back to Phase 7 work.
 
 **Newton tab count drifts from `color_maps.len()`**
 
@@ -1030,8 +1031,7 @@ these automatically when committing via Claude Code.
 - Commits: conventional (`feat:`, `fix:`, `perf:`, `refactor:`, `test:`,
   `docs:`, `chore:`) or imperative short titles.
 - One logical change per commit.
-- Include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` for
-  AI-assisted commits.
+- Include attribution for AI-assisted commits.
 - Never push or open PRs without explicit user confirmation.
 
 ### 12.3 Per-phase PR checklist
@@ -1040,9 +1040,7 @@ these automatically when committing via Claude Code.
 - [ ] Unit tests added for new pure-logic pieces (per §10.1).
 - [ ] Pixel-hash regression tests pass unchanged where applicable
       (Phases 1, 2 especially).
-- [ ] Manual smoke-test on Windows native.
-- [ ] Manual smoke-test on WSL.
-- [ ] Manual smoke-test on native Linux (if available).
+- [ ] Manual smoke-test on various platforms (WSL, windows, mac, linux).
 - [ ] If a hot path changed: `cargo bench` comparison before/after.
 - [ ] If JSON schema changed: every example JSON re-loads and produces the
       same image hash (or a documented and intended pixel difference).


### PR DESCRIPTION
**Summary:**  Adds a full roadmap document for the plan to upgrade and integrate the color and explore GUI applications. Developed based on interviews with Claude. From here we can pick off one step at a time, updating the roadmap after each successive PR. 