### PR TITLE
Gui unification:  phase one data structure unification

### DIFF
--- a/benches/mandelbrot_default.json
+++ b/benches/mandelbrot_default.json
@@ -10,26 +10,28 @@
     "refinement_count": 5
   },
   "color_map": {
-    "keyframes": [
-      {
-        "query": 0.0,
-        "rgb_raw": [50, 0, 100]
-      },
-      {
-        "query": 0.92,
-        "rgb_raw": [20, 0, 220]
-      },
-      {
-        "query": 0.97,
-        "rgb_raw": [0, 50, 230]
-      },
-      {
-        "query": 1.0,
-        "rgb_raw": [230, 245, 255]
-      }
-    ],
+    "color": {
+      "background": [0, 0, 0],
+      "color_map": [
+        {
+          "query": 0.0,
+          "rgb_raw": [50, 0, 100]
+        },
+        {
+          "query": 0.92,
+          "rgb_raw": [20, 0, 220]
+        },
+        {
+          "query": 0.97,
+          "rgb_raw": [0, 50, 230]
+        },
+        {
+          "query": 1.0,
+          "rgb_raw": [230, 245, 255]
+        }
+      ]
+    },
     "lookup_table_count": 2048,
-    "background_color_rgb": [0, 0, 0],
     "histogram_bin_count": 32,
     "histogram_sample_count": 40000
   },

--- a/benches/mandelbrot_ice_fracture.json
+++ b/benches/mandelbrot_ice_fracture.json
@@ -10,30 +10,32 @@
     "refinement_count": 5
   },
   "color_map": {
-    "keyframes": [
-      {
-        "query": 0.0,
-        "rgb_raw": [0, 0, 250]
-      },
-      {
-        "query": 0.9,
-        "rgb_raw": [40, 0, 80]
-      },
-      {
-        "query": 0.94,
-        "rgb_raw": [255, 125, 0]
-      },
-      {
-        "query": 0.99,
-        "rgb_raw": [10, 0, 20]
-      },
-      {
-        "query": 1.0,
-        "rgb_raw": [255, 150, 150]
-      }
-    ],
+    "color": {
+      "background": [0, 0, 0],
+      "color_map": [
+        {
+          "query": 0.0,
+          "rgb_raw": [0, 0, 250]
+        },
+        {
+          "query": 0.9,
+          "rgb_raw": [40, 0, 80]
+        },
+        {
+          "query": 0.94,
+          "rgb_raw": [255, 125, 0]
+        },
+        {
+          "query": 0.99,
+          "rgb_raw": [10, 0, 20]
+        },
+        {
+          "query": 1.0,
+          "rgb_raw": [255, 150, 150]
+        }
+      ]
+    },
     "lookup_table_count": 2048,
-    "background_color_rgb": [0, 0, 0],
     "histogram_bin_count": 32,
     "histogram_sample_count": 20000
   },

--- a/examples/color-gui-demo/params.json
+++ b/examples/color-gui-demo/params.json
@@ -11,26 +11,28 @@
       "refinement_count": 3
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [50, 0, 100]
-        },
-        {
-          "query": 0.92,
-          "rgb_raw": [20, 0, 220]
-        },
-        {
-          "query": 0.97,
-          "rgb_raw": [0, 50, 230]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [50, 0, 100]
+          },
+          {
+            "query": 0.92,
+            "rgb_raw": [20, 0, 220]
+          },
+          {
+            "query": 0.97,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 20000
     },

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -71,7 +71,7 @@ pub fn color_editor_example_from_string(example_name: &str) {
     // Early prototype. Eventually this will support the same set of fractal types as `explore`.
     let (keyframes, preview_buffer, resolution) = match fractal_params {
         FractalParams::Mandelbrot(params) => {
-            let kf = params.color_map.keyframes.clone();
+            let kf = params.color_map.color.color_map.clone();
             let resolution = params.image_specification.resolution;
             let renderer = QuadraticMap::new((*params).clone());
             let mut buf = create_buffer(image::Rgb([0u8, 0, 0]), &resolution);

--- a/examples/explore-driven-damped-pendulum-high-fidelity/params.json
+++ b/examples/explore-driven-damped-pendulum-high-fidelity/params.json
@@ -12,6 +12,10 @@
     "render_options": {
       "downsample_stride": 1,
       "subpixel_antialiasing": 6
+    },
+    "color": {
+      "foreground": [255, 255, 255],
+      "background": [0, 0, 0]
     }
   }
 }

--- a/examples/explore-driven-damped-pendulum-quickly/params.json
+++ b/examples/explore-driven-damped-pendulum-quickly/params.json
@@ -12,6 +12,10 @@
     "render_options": {
       "downsample_stride": 1,
       "subpixel_antialiasing": 1
+    },
+    "color": {
+      "foreground": [255, 255, 255],
+      "background": [0, 0, 0]
     }
   }
 }

--- a/examples/explore-julia-brassicas/params.json
+++ b/examples/explore-julia-brassicas/params.json
@@ -12,18 +12,44 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        { "query": 0.0, "rgb_raw": [12, 12, 12] },
-        { "query": 0.88, "rgb_raw": [14, 14, 14] },
-        { "query": 0.92, "rgb_raw": [39, 112, 155] },
-        { "query": 0.94, "rgb_raw": [132, 92, 162] },
-        { "query": 0.96, "rgb_raw": [223, 73, 119] },
-        { "query": 0.98, "rgb_raw": [237, 81, 40] },
-        { "query": 0.99, "rgb_raw": [228, 191, 48] },
-        { "query": 1.0, "rgb_raw": [84, 190, 58] }
-      ],
+      "color": {
+        "background": [12, 12, 12],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [12, 12, 12]
+          },
+          {
+            "query": 0.88,
+            "rgb_raw": [14, 14, 14]
+          },
+          {
+            "query": 0.92,
+            "rgb_raw": [39, 112, 155]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [132, 92, 162]
+          },
+          {
+            "query": 0.96,
+            "rgb_raw": [223, 73, 119]
+          },
+          {
+            "query": 0.98,
+            "rgb_raw": [237, 81, 40]
+          },
+          {
+            "query": 0.99,
+            "rgb_raw": [228, 191, 48]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [84, 190, 58]
+          }
+        ]
+      },
       "lookup_table_count": 4096,
-      "background_color_rgb": [12, 12, 12],
       "histogram_bin_count": 64,
       "histogram_sample_count": 100000
     },

--- a/examples/explore-julia-flower/params.json
+++ b/examples/explore-julia-flower/params.json
@@ -12,26 +12,28 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 0, 0]
-        },
-        {
-          "query": 0.8,
-          "rgb_raw": [0, 0, 0]
-        },
-        {
-          "query": 0.96,
-          "rgb_raw": [0, 50, 230]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.8,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.96,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 40000
     },

--- a/examples/explore-julia-spiral/params.json
+++ b/examples/explore-julia-spiral/params.json
@@ -12,17 +12,34 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        { "query": 0.0, "rgb_raw": [0, 0, 0] },
-        { "query": 0.89, "rgb_raw": [0, 0, 0] },
-        { "query": 0.96, "rgb_raw": [0, 50, 230] },
-        { "query": 1.0, "rgb_raw": [230, 245, 255] }
-      ],
+      "color": {
+        "background": [14, 14, 14],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.89,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.96,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 4096,
-      "background_color_rgb": [14, 14, 14],
       "histogram_bin_count": 64,
       "histogram_sample_count": 100000
     },
-    "render_options": { "downsample_stride": 1, "subpixel_antialiasing": 2 }
+    "render_options": {
+      "downsample_stride": 1,
+      "subpixel_antialiasing": 2
+    }
   }
 }

--- a/examples/explore-mandelbrot-awesome-socks/params.json
+++ b/examples/explore-mandelbrot-awesome-socks/params.json
@@ -11,42 +11,44 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [12, 12, 12]
-        },
-        {
-          "query": 0.55,
-          "rgb_raw": [30, 7, 60]
-        },
-        {
-          "query": 0.6,
-          "rgb_raw": [40, 10, 110]
-        },
-        {
-          "query": 0.8,
-          "rgb_raw": [10, 0, 26]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [140, 10, 35]
-        },
-        {
-          "query": 0.94,
-          "rgb_raw": [20, 40, 140]
-        },
-        {
-          "query": 0.97,
-          "rgb_raw": [0, 50, 240]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [250, 250, 200]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [12, 12, 12]
+          },
+          {
+            "query": 0.55,
+            "rgb_raw": [30, 7, 60]
+          },
+          {
+            "query": 0.6,
+            "rgb_raw": [40, 10, 110]
+          },
+          {
+            "query": 0.8,
+            "rgb_raw": [10, 0, 26]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [140, 10, 35]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [20, 40, 140]
+          },
+          {
+            "query": 0.97,
+            "rgb_raw": [0, 50, 240]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [250, 250, 200]
+          }
+        ]
+      },
       "lookup_table_count": 1024,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 512,
       "histogram_sample_count": 100000
     },

--- a/examples/explore-mandelbrot-curvy-spider/params.json
+++ b/examples/explore-mandelbrot-curvy-spider/params.json
@@ -11,26 +11,28 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [100, 40, 0]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [30, 0, 80]
-        },
-        {
-          "query": 0.98,
-          "rgb_raw": [0, 50, 240]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [100, 40, 0]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [30, 0, 80]
+          },
+          {
+            "query": 0.98,
+            "rgb_raw": [0, 50, 240]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 1024,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 64,
       "histogram_sample_count": 50000
     },

--- a/examples/explore-mandelbrot-default/params.json
+++ b/examples/explore-mandelbrot-default/params.json
@@ -11,26 +11,28 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [50, 0, 100]
-        },
-        {
-          "query": 0.92,
-          "rgb_raw": [20, 0, 220]
-        },
-        {
-          "query": 0.97,
-          "rgb_raw": [0, 50, 230]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [50, 0, 100]
+          },
+          {
+            "query": 0.92,
+            "rgb_raw": [20, 0, 220]
+          },
+          {
+            "query": 0.97,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 40000
     },

--- a/examples/explore-mandelbrot-ice-fracture/params.json
+++ b/examples/explore-mandelbrot-ice-fracture/params.json
@@ -11,30 +11,32 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 0, 250]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [40, 0, 80]
-        },
-        {
-          "query": 0.94,
-          "rgb_raw": [255, 125, 0]
-        },
-        {
-          "query": 0.99,
-          "rgb_raw": [10, 0, 20]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [255, 150, 150]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 250]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [40, 0, 80]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [255, 125, 0]
+          },
+          {
+            "query": 0.99,
+            "rgb_raw": [10, 0, 20]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [255, 150, 150]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 20000
     },

--- a/examples/explore-mandelbrot-laser/params.json
+++ b/examples/explore-mandelbrot-laser/params.json
@@ -11,30 +11,32 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 0, 0]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [40, 0, 80]
-        },
-        {
-          "query": 0.94,
-          "rgb_raw": [20, 0, 200]
-        },
-        {
-          "query": 0.98,
-          "rgb_raw": [0, 50, 250]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 240, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [40, 0, 80]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [20, 0, 200]
+          },
+          {
+            "query": 0.98,
+            "rgb_raw": [0, 50, 250]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 240, 255]
+          }
+        ]
+      },
       "lookup_table_count": 5000,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 16,
       "histogram_sample_count": 5000
     },

--- a/examples/explore-mandelbrot-sea-star/params.json
+++ b/examples/explore-mandelbrot-sea-star/params.json
@@ -11,30 +11,32 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 0, 250]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [40, 0, 80]
-        },
-        {
-          "query": 0.94,
-          "rgb_raw": [255, 125, 0]
-        },
-        {
-          "query": 0.99,
-          "rgb_raw": [10, 0, 20]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [255, 150, 150]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 250]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [40, 0, 80]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [255, 125, 0]
+          },
+          {
+            "query": 0.99,
+            "rgb_raw": [10, 0, 20]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [255, 150, 150]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 20000
     },

--- a/examples/explore-mandelbrot-tiny/params.json
+++ b/examples/explore-mandelbrot-tiny/params.json
@@ -11,22 +11,24 @@
       "refinement_count": 2
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 255, 0]
-        },
-        {
-          "query": 0.5,
-          "rgb_raw": [0, 0, 255]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [255, 0, 0]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 255, 0]
+          },
+          {
+            "query": 0.5,
+            "rgb_raw": [0, 0, 255]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [255, 0, 0]
+          }
+        ]
+      },
       "lookup_table_count": 256,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 4,
       "histogram_sample_count": 64
     },

--- a/examples/explore-newton-cosh-minus-one/params.json
+++ b/examples/explore-newton-cosh-minus-one/params.json
@@ -7,25 +7,51 @@
         "width": 5.0
       },
       "max_iteration_count": 124,
-      "convergence_tolerance": 1e-6,
+      "convergence_tolerance": 1e-06,
       "render_options": {
         "downsample_stride": 1,
         "subpixel_antialiasing": 1
       },
-      "boundary_set_color_rgb": [0, 0, 0],
-      "cyclic_attractor_color_rgb": [150, 0, 30],
-      "color_map_spec": {
-        "FullColorSpec": [
+      "color": {
+        "cyclic_attractor": [150, 0, 30],
+        "color_maps": [
           [
-            { "query": 0.0, "rgb_raw": [0, 0, 0] },
-            { "query": 0.45, "rgb_raw": [0, 2, 0] },
-            { "query": 0.5, "rgb_raw": [0, 20, 0] },
-            { "query": 0.59, "rgb_raw": [0, 200, 0] },
-            { "query": 0.63, "rgb_raw": [0, 200, 0] },
-            { "query": 0.7, "rgb_raw": [0, 20, 30] },
-            { "query": 0.94, "rgb_raw": [0, 50, 230] },
-            { "query": 0.97, "rgb_raw": [0, 50, 230] },
-            { "query": 1.0, "rgb_raw": [0, 10, 20] }
+            {
+              "query": 0.0,
+              "rgb_raw": [0, 0, 0]
+            },
+            {
+              "query": 0.45,
+              "rgb_raw": [0, 2, 0]
+            },
+            {
+              "query": 0.5,
+              "rgb_raw": [0, 20, 0]
+            },
+            {
+              "query": 0.59,
+              "rgb_raw": [0, 200, 0]
+            },
+            {
+              "query": 0.63,
+              "rgb_raw": [0, 200, 0]
+            },
+            {
+              "query": 0.7,
+              "rgb_raw": [0, 20, 30]
+            },
+            {
+              "query": 0.94,
+              "rgb_raw": [0, 50, 230]
+            },
+            {
+              "query": 0.97,
+              "rgb_raw": [0, 50, 230]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 10, 20]
+            }
           ]
         ]
       },

--- a/examples/explore-newton-roots-of-unity-4/params.json
+++ b/examples/explore-newton-roots-of-unity-4/params.json
@@ -7,27 +7,71 @@
         "width": 5.0
       },
       "max_iteration_count": 250,
-      "convergence_tolerance": 1e-6,
+      "convergence_tolerance": 1e-06,
       "render_options": {
         "downsample_stride": 1,
         "subpixel_antialiasing": 2
       },
-      "boundary_set_color_rgb": [0, 0, 0],
-      "cyclic_attractor_color_rgb": [255, 255, 255],
-      "color_map_spec": {
-        "GrayscaleSpec": {
-          "root_colors_rgb": [
-            [18, 83, 53],
-            [170, 30, 78],
-            [30, 95, 175],
-            [228, 173, 55]
+      "color": {
+        "cyclic_attractor": [255, 255, 255],
+        "color_maps": [
+          [
+            {
+              "query": 0.0,
+              "rgb_raw": [9, 42, 27]
+            },
+            {
+              "query": 0.92,
+              "rgb_raw": [5, 21, 13]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 0, 0]
+            }
           ],
-          "grayscale_keyframes": [
-            { "query": 0.0, "value": 0.5 },
-            { "query": 0.92, "value": 0.75 },
-            { "query": 1.0, "value": 1.0 }
+          [
+            {
+              "query": 0.0,
+              "rgb_raw": [85, 15, 39]
+            },
+            {
+              "query": 0.92,
+              "rgb_raw": [43, 8, 20]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 0, 0]
+            }
+          ],
+          [
+            {
+              "query": 0.0,
+              "rgb_raw": [15, 48, 88]
+            },
+            {
+              "query": 0.92,
+              "rgb_raw": [8, 24, 44]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 0, 0]
+            }
+          ],
+          [
+            {
+              "query": 0.0,
+              "rgb_raw": [114, 87, 28]
+            },
+            {
+              "query": 0.92,
+              "rgb_raw": [57, 43, 14]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 0, 0]
+            }
           ]
-        }
+        ]
       },
       "lookup_table_count": 512,
       "histogram_bin_count": 512,

--- a/examples/render-driven-damped-pendulum-high-fidelity/params.json
+++ b/examples/render-driven-damped-pendulum-high-fidelity/params.json
@@ -12,6 +12,10 @@
     "render_options": {
       "downsample_stride": 1,
       "subpixel_antialiasing": 6
+    },
+    "color": {
+      "foreground": [255, 255, 255],
+      "background": [0, 0, 0]
     }
   }
 }

--- a/examples/render-driven-damped-pendulum-quickly/params.json
+++ b/examples/render-driven-damped-pendulum-quickly/params.json
@@ -12,6 +12,10 @@
     "render_options": {
       "downsample_stride": 1,
       "subpixel_antialiasing": 1
+    },
+    "color": {
+      "foreground": [255, 255, 255],
+      "background": [0, 0, 0]
     }
   }
 }

--- a/examples/render-driven-damped-pendulum/params.json
+++ b/examples/render-driven-damped-pendulum/params.json
@@ -12,6 +12,10 @@
     "render_options": {
       "downsample_stride": 1,
       "subpixel_antialiasing": 2
+    },
+    "color": {
+      "foreground": [255, 255, 255],
+      "background": [0, 0, 0]
     }
   }
 }

--- a/examples/render-julia-brassicas/params.json
+++ b/examples/render-julia-brassicas/params.json
@@ -12,18 +12,44 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        { "query": 0.0, "rgb_raw": [12, 12, 12] },
-        { "query": 0.88, "rgb_raw": [14, 14, 14] },
-        { "query": 0.92, "rgb_raw": [39, 112, 155] },
-        { "query": 0.94, "rgb_raw": [132, 92, 162] },
-        { "query": 0.96, "rgb_raw": [223, 73, 119] },
-        { "query": 0.98, "rgb_raw": [237, 81, 40] },
-        { "query": 0.99, "rgb_raw": [228, 191, 48] },
-        { "query": 1.0, "rgb_raw": [84, 190, 58] }
-      ],
+      "color": {
+        "background": [12, 12, 12],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [12, 12, 12]
+          },
+          {
+            "query": 0.88,
+            "rgb_raw": [14, 14, 14]
+          },
+          {
+            "query": 0.92,
+            "rgb_raw": [39, 112, 155]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [132, 92, 162]
+          },
+          {
+            "query": 0.96,
+            "rgb_raw": [223, 73, 119]
+          },
+          {
+            "query": 0.98,
+            "rgb_raw": [237, 81, 40]
+          },
+          {
+            "query": 0.99,
+            "rgb_raw": [228, 191, 48]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [84, 190, 58]
+          }
+        ]
+      },
       "lookup_table_count": 4096,
-      "background_color_rgb": [12, 12, 12],
       "histogram_bin_count": 64,
       "histogram_sample_count": 100000
     },

--- a/examples/render-julia-flower/params.json
+++ b/examples/render-julia-flower/params.json
@@ -12,26 +12,28 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 0, 0]
-        },
-        {
-          "query": 0.8,
-          "rgb_raw": [0, 0, 0]
-        },
-        {
-          "query": 0.96,
-          "rgb_raw": [0, 50, 230]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.8,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.96,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 40000
     },

--- a/examples/render-julia-spiral/params.json
+++ b/examples/render-julia-spiral/params.json
@@ -12,17 +12,34 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        { "query": 0.0, "rgb_raw": [0, 0, 0] },
-        { "query": 0.89, "rgb_raw": [0, 0, 0] },
-        { "query": 0.96, "rgb_raw": [0, 50, 230] },
-        { "query": 1.0, "rgb_raw": [230, 245, 255] }
-      ],
+      "color": {
+        "background": [14, 14, 14],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.89,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.96,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 4096,
-      "background_color_rgb": [14, 14, 14],
       "histogram_bin_count": 64,
       "histogram_sample_count": 100000
     },
-    "render_options": { "downsample_stride": 1, "subpixel_antialiasing": 2 }
+    "render_options": {
+      "downsample_stride": 1,
+      "subpixel_antialiasing": 2
+    }
   }
 }

--- a/examples/render-mandelbrot-awesome-socks/params.json
+++ b/examples/render-mandelbrot-awesome-socks/params.json
@@ -11,42 +11,44 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [12, 12, 12]
-        },
-        {
-          "query": 0.55,
-          "rgb_raw": [30, 7, 60]
-        },
-        {
-          "query": 0.6,
-          "rgb_raw": [40, 10, 110]
-        },
-        {
-          "query": 0.8,
-          "rgb_raw": [10, 0, 26]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [140, 10, 35]
-        },
-        {
-          "query": 0.94,
-          "rgb_raw": [20, 40, 140]
-        },
-        {
-          "query": 0.97,
-          "rgb_raw": [0, 50, 240]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [250, 250, 200]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [12, 12, 12]
+          },
+          {
+            "query": 0.55,
+            "rgb_raw": [30, 7, 60]
+          },
+          {
+            "query": 0.6,
+            "rgb_raw": [40, 10, 110]
+          },
+          {
+            "query": 0.8,
+            "rgb_raw": [10, 0, 26]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [140, 10, 35]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [20, 40, 140]
+          },
+          {
+            "query": 0.97,
+            "rgb_raw": [0, 50, 240]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [250, 250, 200]
+          }
+        ]
+      },
       "lookup_table_count": 1024,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 512,
       "histogram_sample_count": 100000
     },

--- a/examples/render-mandelbrot-curvy-spider/params.json
+++ b/examples/render-mandelbrot-curvy-spider/params.json
@@ -11,26 +11,28 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [100, 40, 0]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [30, 0, 80]
-        },
-        {
-          "query": 0.98,
-          "rgb_raw": [0, 50, 240]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [100, 40, 0]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [30, 0, 80]
+          },
+          {
+            "query": 0.98,
+            "rgb_raw": [0, 50, 240]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 1024,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 64,
       "histogram_sample_count": 50000
     },

--- a/examples/render-mandelbrot-default-fast/params.json
+++ b/examples/render-mandelbrot-default-fast/params.json
@@ -11,26 +11,28 @@
       "refinement_count": 4
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [50, 0, 100]
-        },
-        {
-          "query": 0.92,
-          "rgb_raw": [20, 0, 220]
-        },
-        {
-          "query": 0.97,
-          "rgb_raw": [0, 50, 230]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [50, 0, 100]
+          },
+          {
+            "query": 0.92,
+            "rgb_raw": [20, 0, 220]
+          },
+          {
+            "query": 0.97,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 1024,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 24,
       "histogram_sample_count": 10000
     },

--- a/examples/render-mandelbrot-default/params.json
+++ b/examples/render-mandelbrot-default/params.json
@@ -11,26 +11,28 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [50, 0, 100]
-        },
-        {
-          "query": 0.92,
-          "rgb_raw": [20, 0, 220]
-        },
-        {
-          "query": 0.97,
-          "rgb_raw": [0, 50, 230]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [50, 0, 100]
+          },
+          {
+            "query": 0.92,
+            "rgb_raw": [20, 0, 220]
+          },
+          {
+            "query": 0.97,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 40000
     },

--- a/examples/render-mandelbrot-ice-fracture/params.json
+++ b/examples/render-mandelbrot-ice-fracture/params.json
@@ -11,30 +11,32 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 0, 250]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [40, 0, 80]
-        },
-        {
-          "query": 0.94,
-          "rgb_raw": [255, 125, 0]
-        },
-        {
-          "query": 0.99,
-          "rgb_raw": [10, 0, 20]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [255, 150, 150]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 250]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [40, 0, 80]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [255, 125, 0]
+          },
+          {
+            "query": 0.99,
+            "rgb_raw": [10, 0, 20]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [255, 150, 150]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 20000
     },

--- a/examples/render-mandelbrot-laser/params.json
+++ b/examples/render-mandelbrot-laser/params.json
@@ -11,30 +11,32 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 0, 0]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [40, 0, 80]
-        },
-        {
-          "query": 0.94,
-          "rgb_raw": [20, 0, 200]
-        },
-        {
-          "query": 0.98,
-          "rgb_raw": [0, 50, 250]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 240, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 0]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [40, 0, 80]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [20, 0, 200]
+          },
+          {
+            "query": 0.98,
+            "rgb_raw": [0, 50, 250]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 240, 255]
+          }
+        ]
+      },
       "lookup_table_count": 5000,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 16,
       "histogram_sample_count": 5000
     },

--- a/examples/render-mandelbrot-sea-star/params.json
+++ b/examples/render-mandelbrot-sea-star/params.json
@@ -11,30 +11,32 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 0, 250]
-        },
-        {
-          "query": 0.9,
-          "rgb_raw": [40, 0, 80]
-        },
-        {
-          "query": 0.94,
-          "rgb_raw": [255, 125, 0]
-        },
-        {
-          "query": 0.99,
-          "rgb_raw": [10, 0, 20]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [255, 150, 150]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 0, 250]
+          },
+          {
+            "query": 0.9,
+            "rgb_raw": [40, 0, 80]
+          },
+          {
+            "query": 0.94,
+            "rgb_raw": [255, 125, 0]
+          },
+          {
+            "query": 0.99,
+            "rgb_raw": [10, 0, 20]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [255, 150, 150]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 20000
     },

--- a/examples/render-mandelbrot-tiny/params.json
+++ b/examples/render-mandelbrot-tiny/params.json
@@ -11,22 +11,24 @@
       "refinement_count": 2
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [0, 255, 0]
-        },
-        {
-          "query": 0.5,
-          "rgb_raw": [0, 0, 255]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [255, 0, 0]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [0, 255, 0]
+          },
+          {
+            "query": 0.5,
+            "rgb_raw": [0, 0, 255]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [255, 0, 0]
+          }
+        ]
+      },
       "lookup_table_count": 256,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 4,
       "histogram_sample_count": 64
     },

--- a/examples/render-mandelbrot/params.json
+++ b/examples/render-mandelbrot/params.json
@@ -11,26 +11,28 @@
       "refinement_count": 5
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [50, 0, 100]
-        },
-        {
-          "query": 0.92,
-          "rgb_raw": [20, 0, 220]
-        },
-        {
-          "query": 0.97,
-          "rgb_raw": [0, 50, 230]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [50, 0, 100]
+          },
+          {
+            "query": 0.92,
+            "rgb_raw": [20, 0, 220]
+          },
+          {
+            "query": 0.97,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 2048,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 40000
     },

--- a/examples/render-newton-cosh-minus-one/params.json
+++ b/examples/render-newton-cosh-minus-one/params.json
@@ -7,22 +7,39 @@
         "width": 2.3
       },
       "max_iteration_count": 512,
-      "convergence_tolerance": 1e-6,
+      "convergence_tolerance": 1e-06,
       "render_options": {
         "downsample_stride": 1,
         "subpixel_antialiasing": 3
       },
-      "boundary_set_color_rgb": [0, 0, 0],
-      "cyclic_attractor_color_rgb": [150, 0, 30],
-      "color_map_spec": {
-        "FullColorSpec": [
+      "color": {
+        "cyclic_attractor": [150, 0, 30],
+        "color_maps": [
           [
-            { "query": 0.0, "rgb_raw": [0, 0, 0] },
-            { "query": 0.45, "rgb_raw": [0, 10, 15] },
-            { "query": 0.5, "rgb_raw": [0, 200, 0] },
-            { "query": 0.65, "rgb_raw": [0, 20, 30] },
-            { "query": 0.94, "rgb_raw": [0, 50, 230] },
-            { "query": 1.0, "rgb_raw": [0, 10, 20] }
+            {
+              "query": 0.0,
+              "rgb_raw": [0, 0, 0]
+            },
+            {
+              "query": 0.45,
+              "rgb_raw": [0, 10, 15]
+            },
+            {
+              "query": 0.5,
+              "rgb_raw": [0, 200, 0]
+            },
+            {
+              "query": 0.65,
+              "rgb_raw": [0, 20, 30]
+            },
+            {
+              "query": 0.94,
+              "rgb_raw": [0, 50, 230]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 10, 20]
+            }
           ]
         ]
       },

--- a/examples/render-newton-roots-of-unity-4/params.json
+++ b/examples/render-newton-roots-of-unity-4/params.json
@@ -7,27 +7,71 @@
         "width": 5.0
       },
       "max_iteration_count": 500,
-      "convergence_tolerance": 1e-8,
+      "convergence_tolerance": 1e-08,
       "render_options": {
         "downsample_stride": 1,
         "subpixel_antialiasing": 4
       },
-      "boundary_set_color_rgb": [0, 0, 0],
-      "cyclic_attractor_color_rgb": [255, 255, 255],
-      "color_map_spec": {
-        "GrayscaleSpec": {
-          "root_colors_rgb": [
-            [18, 83, 53],
-            [170, 30, 78],
-            [30, 95, 175],
-            [228, 173, 55]
+      "color": {
+        "cyclic_attractor": [255, 255, 255],
+        "color_maps": [
+          [
+            {
+              "query": 0.0,
+              "rgb_raw": [9, 42, 27]
+            },
+            {
+              "query": 0.92,
+              "rgb_raw": [5, 21, 13]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 0, 0]
+            }
           ],
-          "grayscale_keyframes": [
-            { "query": 0.0, "value": 0.5 },
-            { "query": 0.92, "value": 0.75 },
-            { "query": 1.0, "value": 1.0 }
+          [
+            {
+              "query": 0.0,
+              "rgb_raw": [85, 15, 39]
+            },
+            {
+              "query": 0.92,
+              "rgb_raw": [43, 8, 20]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 0, 0]
+            }
+          ],
+          [
+            {
+              "query": 0.0,
+              "rgb_raw": [15, 48, 88]
+            },
+            {
+              "query": 0.92,
+              "rgb_raw": [8, 24, 44]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 0, 0]
+            }
+          ],
+          [
+            {
+              "query": 0.0,
+              "rgb_raw": [114, 87, 28]
+            },
+            {
+              "query": 0.92,
+              "rgb_raw": [57, 43, 14]
+            },
+            {
+              "query": 1.0,
+              "rgb_raw": [0, 0, 0]
+            }
           ]
-        }
+        ]
       },
       "lookup_table_count": 512,
       "histogram_bin_count": 512,

--- a/src/core/color_map.rs
+++ b/src/core/color_map.rs
@@ -16,6 +16,40 @@ pub struct ColorMapKeyFrame {
     pub rgb_raw: [u8; 3], // [R, G, B]
 }
 
+/// Solid foreground / solid background pair. Used by basin-style fractals
+/// (e.g. driven-damped pendulum) where a per-pixel `Option<i32>` selects one
+/// or the other.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ForegroundBackground {
+    /// Color used for the "in-set" / zeroth-basin pixel value.
+    pub foreground: [u8; 3],
+    /// Color used for every other pixel value (including non-converged).
+    pub background: [u8; 3],
+}
+
+/// One gradient plus a solid background. Used by escape-time fractals
+/// (Mandelbrot, Julia) where escaped pixels go through the gradient and
+/// non-escaped pixels take the background color.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BackgroundWithColorMap {
+    /// Color used for pixels that did not produce a smooth-iteration value.
+    pub background: [u8; 3],
+    /// Keyframes describing the gradient applied to escaped pixels.
+    pub color_map: Vec<ColorMapKeyFrame>,
+}
+
+/// Multiple gradients plus a solid "didn't converge" color. Used by Newton's
+/// method, where a per-pixel `(smooth_iter, root_index)` picks the gradient.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MultiColorMap {
+    /// Color used when Newton iteration enters a cyclic attractor and never
+    /// converges to a root.
+    pub cyclic_attractor: [u8; 3],
+    /// One gradient per root. The root index selects which gradient applies
+    /// to a given pixel.
+    pub color_maps: Vec<Vec<ColorMapKeyFrame>>,
+}
+
 pub trait ColorMapper {
     fn compute_pixel(&self, query: f32) -> image::Rgb<u8>;
 }
@@ -199,5 +233,76 @@ mod tests {
 
         assert_eq!(table.compute_pixel(-1.0), Rgb([0, 0, 0]));
         assert_eq!(table.compute_pixel(2.0), Rgb([255, 0, 255]));
+    }
+
+    #[test]
+    fn test_foreground_background_serde_roundtrip() {
+        let original = ForegroundBackground {
+            foreground: [255, 128, 0],
+            background: [10, 20, 30],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: ForegroundBackground = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.foreground, original.foreground);
+        assert_eq!(parsed.background, original.background);
+    }
+
+    #[test]
+    fn test_background_with_color_map_serde_roundtrip() {
+        let original = BackgroundWithColorMap {
+            background: [0, 0, 0],
+            color_map: vec![
+                ColorMapKeyFrame {
+                    query: 0.0,
+                    rgb_raw: [10, 20, 30],
+                },
+                ColorMapKeyFrame {
+                    query: 1.0,
+                    rgb_raw: [200, 210, 220],
+                },
+            ],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: BackgroundWithColorMap = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.background, original.background);
+        assert_eq!(parsed.color_map.len(), original.color_map.len());
+        for (a, b) in parsed.color_map.iter().zip(original.color_map.iter()) {
+            assert_eq!(a.query, b.query);
+            assert_eq!(a.rgb_raw, b.rgb_raw);
+        }
+    }
+
+    #[test]
+    fn test_multi_color_map_serde_roundtrip() {
+        let original = MultiColorMap {
+            cyclic_attractor: [255, 255, 255],
+            color_maps: vec![
+                vec![
+                    ColorMapKeyFrame {
+                        query: 0.0,
+                        rgb_raw: [1, 2, 3],
+                    },
+                    ColorMapKeyFrame {
+                        query: 1.0,
+                        rgb_raw: [4, 5, 6],
+                    },
+                ],
+                vec![ColorMapKeyFrame {
+                    query: 0.5,
+                    rgb_raw: [7, 8, 9],
+                }],
+            ],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: MultiColorMap = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.cyclic_attractor, original.cyclic_attractor);
+        assert_eq!(parsed.color_maps.len(), original.color_maps.len());
+        for (a, b) in parsed.color_maps.iter().zip(original.color_maps.iter()) {
+            assert_eq!(a.len(), b.len());
+            for (ka, kb) in a.iter().zip(b.iter()) {
+                assert_eq!(ka.query, kb.query);
+                assert_eq!(ka.rgb_raw, kb.rgb_raw);
+            }
+        }
     }
 }

--- a/src/fractals/common.rs
+++ b/src/fractals/common.rs
@@ -15,3 +15,51 @@ pub enum FractalParams {
     Serpinsky(Box<SerpinskyParams>),
     NewtonsMethod(Box<NewtonsMethodParams>),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// JSON whose top-level variant is `Mandelbrot` but whose `color_map`
+    /// payload uses Newton's `MultiColorMap` shape (`cyclic_attractor` +
+    /// `color_maps`) must fail to parse. This documents that color-shape
+    /// pairings are enforced at deserialization, not at runtime.
+    #[test]
+    fn mandelbrot_with_newton_shaped_color_payload_fails_to_parse() {
+        let json = r#"{
+            "Mandelbrot": {
+                "image_specification": {
+                    "resolution": [10, 10],
+                    "center": [0, 0],
+                    "width": 1.0
+                },
+                "convergence_params": {
+                    "escape_radius_squared": 4.0,
+                    "max_iter_count": 4,
+                    "refinement_count": 0
+                },
+                "color_map": {
+                    "color": {
+                        "cyclic_attractor": [255, 255, 255],
+                        "color_maps": [[
+                            { "query": 0.0, "rgb_raw": [0, 0, 0] },
+                            { "query": 1.0, "rgb_raw": [255, 255, 255] }
+                        ]]
+                    },
+                    "lookup_table_count": 8,
+                    "histogram_bin_count": 4,
+                    "histogram_sample_count": 16
+                },
+                "render_options": {
+                    "downsample_stride": 1,
+                    "subpixel_antialiasing": 0
+                }
+            }
+        }"#;
+        let result: Result<FractalParams, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "expected parse failure for Newton-shaped color in Mandelbrot params"
+        );
+    }
+}

--- a/src/fractals/driven_damped_pendulum.rs
+++ b/src/fractals/driven_damped_pendulum.rs
@@ -1,4 +1,5 @@
 use crate::core::{
+    color_map::ForegroundBackground,
     image_utils::{
         ImageSpecification, RenderOptions, Renderable, SpeedOptimizer,
         scale_down_parameter_for_speed, scale_up_parameter_for_speed,
@@ -7,6 +8,16 @@ use crate::core::{
     ode_solvers::rk4_simulate,
 };
 use serde::{Deserialize, Serialize};
+
+/// Default color pair for DDP: white foreground / black background.
+/// Matches the previously hard-coded values, so JSON files written before
+/// the `color` field existed continue to render identically.
+fn ddp_default_color() -> ForegroundBackground {
+    ForegroundBackground {
+        foreground: [255, 255, 255],
+        background: [0, 0, 0],
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DrivenDampedPendulumParams {
@@ -19,6 +30,9 @@ pub struct DrivenDampedPendulumParams {
     // Convergence criteria
     pub periodic_state_error_tolerance: f64,
     pub render_options: RenderOptions,
+    /// Foreground (zeroth-basin) and background (other) colors.
+    #[serde(default = "ddp_default_color")]
+    pub color: ForegroundBackground,
 }
 
 impl Renderable for DrivenDampedPendulumParams {
@@ -32,14 +46,12 @@ impl Renderable for DrivenDampedPendulumParams {
             self.n_steps_per_period,
             self.periodic_state_error_tolerance,
         );
-        // We color the pixel white if it is in the zeroth basin of attraction.
-        // Otherwise, color it black. Alternative coloring schemes could be:
-        // - color each basin a different color.
-        // - grayscale based on angular distance traveled to reach stable orbit
+        // Pixels in the zeroth basin of attraction take the foreground color;
+        // everything else (including non-converged) takes the background.
         if result == Some(0) {
-            image::Rgb([255, 255, 255])
+            image::Rgb(self.color.foreground)
         } else {
-            image::Rgb([0, 0, 0])
+            image::Rgb(self.color.background)
         }
     }
 
@@ -190,4 +202,35 @@ pub fn compute_basin_of_attraction(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pre-Phase-1 DDP params JSON has no `color` field. The
+    /// `#[serde(default)]` shim must fill it with white-foreground /
+    /// black-background — matching the previously hard-coded values — so
+    /// existing files render identically.
+    #[test]
+    fn parses_legacy_json_without_color_field_with_default_white_black() {
+        let json = r#"{
+            "image_specification": {
+                "resolution": [400, 200],
+                "center": [0, 0],
+                "width": 14
+            },
+            "time_phase": 0,
+            "n_max_period": 50,
+            "n_steps_per_period": 12,
+            "periodic_state_error_tolerance": 0.05,
+            "render_options": {
+                "downsample_stride": 1,
+                "subpixel_antialiasing": 1
+            }
+        }"#;
+        let parsed: DrivenDampedPendulumParams = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.color.foreground, [255, 255, 255]);
+        assert_eq!(parsed.color.background, [0, 0, 0]);
+    }
 }

--- a/src/fractals/newtons_method.rs
+++ b/src/fractals/newtons_method.rs
@@ -4,14 +4,14 @@ use std::{f64::consts::PI, fmt::Debug, sync::Arc};
 
 use crate::{
     core::{
-        color_map::{ColorMap, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper},
+        color_map::{ColorMap, ColorMapLookUpTable, ColorMapper, MultiColorMap},
         file_io::FilePrefix,
         histogram::{CumulativeDistributionFunction, Histogram},
         image_utils::{
             self, ImageSpecification, RenderOptions, Renderable, SpeedOptimizer,
             scale_down_parameter_for_speed, scale_up_parameter_for_speed,
         },
-        interpolation::{ClampedLogInterpolator, Interpolator, LinearInterpolator},
+        interpolation::{ClampedLogInterpolator, LinearInterpolator},
         user_interface,
     },
     fractals::utilities::{populate_histogram, reset_color_map_lookup_table_from_cdf},
@@ -183,85 +183,25 @@ pub fn newton_rhapson_iteration_sequence<F: ComplexFunctionWithSlope>(
     None
 }
 
-// Used to interpolate between two color values based on the iterations
-// required for the Newton-Raphson method to converge to a root.
-// Query values of 0 map to `iteration_limits[0]` and values of 1 map to
-// `max_iteration_count`. The `value` of zero corresponds to the common
-// background color, while a `value` of one corresponds to the foreground
-// color associated with the root that the iteration converges to.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
-pub struct GrayscaleMapKeyFrame {
-    pub query: f32,
-    pub value: f32,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GrayscaleKeyframeSpec {
-    pub root_colors_rgb: Vec<[u8; 3]>,
-    pub grayscale_keyframes: Vec<GrayscaleMapKeyFrame>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum ColorMapSpec {
-    FullColorSpec(Vec<Vec<ColorMapKeyFrame>>),
-    GrayscaleSpec(GrayscaleKeyframeSpec),
-}
-
-impl ColorMapSpec {
-    pub fn to_color_map_vec(
-        &self,
-        boundary_set_color_rgb: [u8; 3],
-    ) -> Vec<ColorMap<LinearInterpolator>> {
-        match self {
-            ColorMapSpec::GrayscaleSpec(spec) => spec
-                .root_colors_rgb
-                .iter()
-                .map(|root_color| {
-                    let keyframes: Vec<ColorMapKeyFrame> = spec
-                        .grayscale_keyframes
-                        .iter()
-                        .map(|keyframe| {
-                            let mut rgb = [0u8; 3];
-                            for i in 0..3 {
-                                let color = LinearInterpolator.interpolate(
-                                    keyframe.value,
-                                    root_color[i] as f32,
-                                    boundary_set_color_rgb[i] as f32,
-                                );
-                                rgb[i] = color.clamp(0.0, 255.0).round() as u8;
-                            }
-                            ColorMapKeyFrame {
-                                query: keyframe.query,
-                                rgb_raw: rgb,
-                            }
-                        })
-                        .collect();
-
-                    ColorMap::new(&keyframes, LinearInterpolator)
-                })
-                .collect(),
-
-            ColorMapSpec::FullColorSpec(spec) => spec
-                .iter()
-                .map(|keyframes| ColorMap::new(keyframes, LinearInterpolator))
-                .collect(),
-        }
-    }
-}
-
 /// These parameters are common to all Newton's method fractals, and are not
 /// generic over the specific system being solved.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CommonParams {
+    /// Image dimensions and viewport.
     pub image_specification: ImageSpecification,
+    /// Maximum number of Newton-Raphson iterations before giving up.
     pub max_iteration_count: u32,
+    /// Tolerance used to detect convergence to a root.
     pub convergence_tolerance: f64,
+    /// Rendering options (anti-aliasing, downsampling, etc.).
     pub render_options: RenderOptions,
-    pub boundary_set_color_rgb: [u8; 3],
-    pub cyclic_attractor_color_rgb: [u8; 3], // color for "did not converge"
-    pub color_map_spec: ColorMapSpec,        // defines color map for each root
+    /// Per-root gradients plus the cyclic-attractor (non-converged) color.
+    pub color: MultiColorMap,
+    /// Number of entries in each precomputed color lookup table.
     pub lookup_table_count: usize,
+    /// Number of bins in the shared histogram used to normalize gradients.
     pub histogram_bin_count: usize,
+    /// Number of samples drawn from the image when populating the histogram.
     pub histogram_sample_count: usize,
 }
 
@@ -292,18 +232,21 @@ pub struct NewtonsMethodRenderable<F: ComplexFunctionWithSlope> {
 
 impl<F: ComplexFunctionWithSlope> NewtonsMethodRenderable<F> {
     pub fn new(params: CommonParams, system: F) -> Self {
-        let inner_color_maps = params
-            .color_map_spec
-            .to_color_map_vec(params.boundary_set_color_rgb);
+        let inner_color_maps: Vec<ColorMap<LinearInterpolator>> = params
+            .color
+            .color_maps
+            .iter()
+            .map(|kfs| ColorMap::new(kfs, LinearInterpolator))
+            .collect();
+
+        if inner_color_maps.is_empty() {
+            panic!("color.color_maps must define at least one color map");
+        }
 
         let color_maps: Vec<ColorMapLookUpTable> = inner_color_maps
             .iter()
             .map(|cm| ColorMapLookUpTable::from_color_map(cm, params.lookup_table_count))
             .collect();
-
-        if color_maps.is_empty() {
-            panic!("color_map_spec must define at least one color map");
-        }
 
         let histogram = Histogram::new(
             params.histogram_bin_count,
@@ -418,7 +361,7 @@ where
             match self.newton_rhapson_iteration_sequence(Complex64::new(point[0], point[1])) {
                 Some(res) => res,
                 None => {
-                    return image::Rgb(self.params.cyclic_attractor_color_rgb);
+                    return image::Rgb(self.params.color.cyclic_attractor);
                 }
             };
 

--- a/src/fractals/quadratic_map.rs
+++ b/src/fractals/quadratic_map.rs
@@ -4,7 +4,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use crate::{
     core::{
-        color_map::{ColorMap, ColorMapKeyFrame, ColorMapLookUpTable, ColorMapper},
+        color_map::{BackgroundWithColorMap, ColorMap, ColorMapLookUpTable, ColorMapper},
         histogram::{CumulativeDistributionFunction, Histogram},
         image_utils::{
             ImageSpecification, RenderOptions, Renderable, SpeedOptimizer,
@@ -15,12 +15,19 @@ use crate::{
     fractals::utilities::{populate_histogram, reset_color_map_lookup_table_from_cdf},
 };
 
+/// Parameter block for the colorization step of escape-time fractals
+/// (Mandelbrot, Julia). The `color` field holds the user-facing palette;
+/// the remaining fields tune the histogram-based normalization and the
+/// pre-baked lookup table.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ColorMapParams {
-    pub keyframes: Vec<ColorMapKeyFrame>,
+    /// Background color and gradient keyframes for escaped pixels.
+    pub color: BackgroundWithColorMap,
+    /// Number of entries in the precomputed color lookup table.
     pub lookup_table_count: usize,
-    pub background_color_rgb: [u8; 3],
+    /// Number of bins used by the histogram that drives gradient normalization.
     pub histogram_bin_count: usize,
+    /// Number of samples drawn from the image when populating the histogram.
     pub histogram_sample_count: usize,
 }
 
@@ -203,8 +210,10 @@ pub struct QuadraticMap<T: QuadraticMapParams> {
 
 impl<T: QuadraticMapParams> QuadraticMap<T> {
     pub fn new(fractal_params: T) -> QuadraticMap<T> {
-        let inner_color_map =
-            ColorMap::new(&fractal_params.color_map().keyframes, LinearInterpolator {});
+        let inner_color_map = ColorMap::new(
+            &fractal_params.color_map().color.color_map,
+            LinearInterpolator {},
+        );
         let histogram = create_empty_histogram(&fractal_params);
         let mut quadratic_map = QuadraticMap {
             cdf: CumulativeDistributionFunction::new(&histogram),
@@ -214,7 +223,7 @@ impl<T: QuadraticMapParams> QuadraticMap<T> {
                 fractal_params.color_map().lookup_table_count,
             ),
             inner_color_map,
-            background_color: Rgb(fractal_params.color_map().background_color_rgb),
+            background_color: Rgb(fractal_params.color_map().color.background),
             fractal_params: fractal_params.clone(),
         };
         quadratic_map.update_color_map();

--- a/tests/param_files/driven_damped_pendulum/default_regression_test.json
+++ b/tests/param_files/driven_damped_pendulum/default_regression_test.json
@@ -12,6 +12,10 @@
     "render_options": {
       "downsample_stride": 1,
       "subpixel_antialiasing": 2
+    },
+    "color": {
+      "foreground": [255, 255, 255],
+      "background": [0, 0, 0]
     }
   }
 }

--- a/tests/param_files/julia/default_regression_test.json
+++ b/tests/param_files/julia/default_regression_test.json
@@ -12,22 +12,24 @@
       "refinement_count": 2
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [50, 0, 100]
-        },
-        {
-          "query": 0.5,
-          "rgb_raw": [0, 50, 230]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [230, 245, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [50, 0, 100]
+          },
+          {
+            "query": 0.5,
+            "rgb_raw": [0, 50, 230]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [230, 245, 255]
+          }
+        ]
+      },
       "lookup_table_count": 128,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 16,
       "histogram_sample_count": 80
     },

--- a/tests/param_files/mandelbrot/anti_aliasing_regression_test.json
+++ b/tests/param_files/mandelbrot/anti_aliasing_regression_test.json
@@ -11,22 +11,24 @@
       "refinement_count": 3
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [255, 0, 0]
-        },
-        {
-          "query": 0.5,
-          "rgb_raw": [0, 255, 0]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [0, 0, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [255, 0, 0]
+          },
+          {
+            "query": 0.5,
+            "rgb_raw": [0, 255, 0]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [0, 0, 255]
+          }
+        ]
+      },
       "lookup_table_count": 256,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 80
     },

--- a/tests/param_files/mandelbrot/default_regression_test.json
+++ b/tests/param_files/mandelbrot/default_regression_test.json
@@ -11,18 +11,20 @@
       "refinement_count": 3
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [255, 0, 0]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [0, 0, 255]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [255, 0, 0]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [0, 0, 255]
+          }
+        ]
+      },
       "lookup_table_count": 256,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 80
     },

--- a/tests/param_files/mandelbrot/downsample_interpolation_regression_test.json
+++ b/tests/param_files/mandelbrot/downsample_interpolation_regression_test.json
@@ -11,26 +11,28 @@
       "refinement_count": 3
     },
     "color_map": {
-      "keyframes": [
-        {
-          "query": 0.0,
-          "rgb_raw": [100, 200, 0]
-        },
-        {
-          "query": 0.5,
-          "rgb_raw": [0, 50, 20]
-        },
-        {
-          "query": 0.7,
-          "rgb_raw": [255, 0, 200]
-        },
-        {
-          "query": 1.0,
-          "rgb_raw": [10, 50, 155]
-        }
-      ],
+      "color": {
+        "background": [0, 0, 0],
+        "color_map": [
+          {
+            "query": 0.0,
+            "rgb_raw": [100, 200, 0]
+          },
+          {
+            "query": 0.5,
+            "rgb_raw": [0, 50, 20]
+          },
+          {
+            "query": 0.7,
+            "rgb_raw": [255, 0, 200]
+          },
+          {
+            "query": 1.0,
+            "rgb_raw": [10, 50, 155]
+          }
+        ]
+      },
       "lookup_table_count": 256,
-      "background_color_rgb": [0, 0, 0],
       "histogram_bin_count": 32,
       "histogram_sample_count": 160
     },


### PR DESCRIPTION
## Summary

Phase 1 of the GUI unification roadmap (color-map data unification, see
docs/gui-unification-roadmap.md §6 Phase 1). Introduces three concrete
color-map structs and embeds each fractal type's matching struct directly
in its params. Pure data-shape migration; renderer behavior is unchanged.

- Adds `ForegroundBackground`, `BackgroundWithColorMap`, `MultiColorMap`
  in `core::color_map` with serde round-trip tests.
- Replaces `ColorMapParams.{keyframes, background_color_rgb}` with a
  nested `BackgroundWithColorMap` (Mandelbrot, Julia).
- Adds a `color: ForegroundBackground` field to DDP, with a serde
  default matching the previously hard-coded white/black literals.
- Drops Newton's `GrayscaleMapKeyFrame`, `GrayscaleKeyframeSpec`,
  `ColorMapSpec`, and `to_color_map_vec`. `CommonParams` now carries a
  single `color: MultiColorMap` field.
- Migrates every example/test/bench JSON across the three fractal
  families (~37 files). The roots-of-unity-4 `GrayscaleSpec` is expanded
  by hand into four explicit per-root gradients, with values captured
  under the project's existing `LinearInterpolator` + clamp-and-round
  pipeline before that code was deleted.
- Adds a negative serde test asserting that a Mandelbrot variant with a
  Newton-shaped color payload fails to parse.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 61 unit + 1 validation + 2 pixel-hash regression tests pass
- [x] `cargo bench --no-run`
- [x] Visual diff of Newton renders pre/post migration (no automated
      regression test exists for Newton; reviewer to spot-check
      `examples/render-newton-roots-of-unity-4` and
      `examples/render-newton-cosh-minus-one`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)