### PR TITLE
Feature/prettier json md formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,10 @@
           {
             "type": "command",
             "command": "if python3 -c \"import os,json,sys; cmd=json.loads(os.environ.get('CLAUDE_TOOL_INPUT') or '{}').get('command',''); sys.exit(0 if 'git commit' in cmd else 1)\"; then cargo bench --no-run; fi"
+          },
+          {
+            "type": "command",
+            "command": "if python3 -c \"import os,json,sys; cmd=json.loads(os.environ.get('CLAUDE_TOOL_INPUT') or '{}').get('command',''); sys.exit(0 if 'git commit' in cmd else 1)\"; then npm run fmt:check; fi"
           }
         ]
       }

--- a/.github/workflows/basic_checks.yml
+++ b/.github/workflows/basic_checks.yml
@@ -77,3 +77,15 @@ jobs:
         with:
           command: bench
           args: --no-run
+
+  prettier:
+    name: Prettier (JSON + Markdown)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run fmt:check

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,11 @@
 **/*.rs.bk
 Cargo.lock
 
+# Node / Prettier tooling:
+node_modules/
+
 # Editor:
 .vscode/**/*
+# ...except shared workspace settings that should be checked in:
+!.vscode/settings.json
+!.vscode/extensions.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+# Build artifacts
+target/
+out/
+node_modules/
+
+# Auto-generated lockfiles
+Cargo.lock
+package-lock.json
+
+# Licenses (preserve original formatting)
+LICENSE

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "endOfLine": "lf"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "rust-lang.rust-analyzer"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "editor.formatOnSave": true,
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,23 +59,27 @@ examples/             # JSON parameter files for each fractal variant
 Every commit must pass all of these — run them locally in this order:
 
 ```bash
-cargo fmt                    # Fix formatting (CI checks with --check)
+cargo fmt                    # Fix Rust formatting (CI checks with --check)
 cargo clippy -- -D warnings  # Zero warnings
 cargo test                   # All unit and integration tests
 cargo bench --no-run         # Benchmarks must compile
+npm run fmt:check            # Prettier formatting for JSON and Markdown
 ```
+
+JSON and Markdown are formatted with [Prettier](https://prettier.io/). Run `npm install` once to set it up, then `npm run fmt` to auto-format and `npm run fmt:check` to verify. Requires Node ≥14.
 
 ## Workflow
 
 ### Before Committing
 
-1. `cargo fmt` — format all files.
+1. `cargo fmt` — format all Rust files.
 2. `cargo clippy -- -D warnings` — fix all warnings before committing.
 3. `cargo test` — verify correctness.
 4. `cargo bench --no-run` — verify benchmarks compile.
-5. If you modified a hot path: `cargo bench` to check for regressions.
+5. `npm run fmt:check` — verify JSON/Markdown formatting (use `npm run fmt` to fix).
+6. If you modified a hot path: `cargo bench` to check for regressions.
 
-When running inside Claude Code, steps 1–4 are enforced automatically by pre-commit hooks in `.claude/settings.json` before any `git commit` executes.
+When running inside Claude Code, steps 1–5 are enforced automatically by pre-commit hooks in `.claude/settings.json` before any `git commit` executes.
 
 ### Adding a New Fractal
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Refer to [`CONTRIBUTING.md`](./CONTRIBUTING.md) file if you are interested in co
 
 This project is covered by the MIT [LICENSE](./LICENSE).
 
-JSON and Markdown formatting via [Prettier](https://prettier.io/) (requires Node ≥14). Run `npm install` once to install it, then `npm run fmt` to auto-format or `npm run fmt:check` to verify. Rust code is formatted and linted with the standard tooling (`cargo fmt`, `cargo clippy`).
+JSON and Markdown formatting uses [Prettier](https://prettier.io/). Run `npm install` once to install it, then `npm run fmt` to auto-format or `npm run fmt:check` to verify. Use a current Node.js release with a recent npm version compatible with the committed `package-lock.json`; if `npm install` fails on an older setup, upgrade npm (or Node.js, which bundles npm). Rust code is formatted and linted with the standard tooling (`cargo fmt`, `cargo clippy`).
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Refer to [`CONTRIBUTING.md`](./CONTRIBUTING.md) file if you are interested in co
 
 This project is covered by the MIT [LICENSE](./LICENSE).
 
-JSON and Markdown formatting via [prettier](https://prettier.io/). Rust code is formatted and linted with the standard tooling.
+JSON and Markdown formatting via [Prettier](https://prettier.io/) (requires Node ≥14). Run `npm install` once to install it, then `npm run fmt` to auto-format or `npm run fmt:check` to verify. Rust code is formatted and linted with the standard tooling (`cargo fmt`, `cargo clippy`).
 
 ## Acknowledgements
 

--- a/examples/explore-newton-cosh-minus-one/params.json
+++ b/examples/explore-newton-cosh-minus-one/params.json
@@ -7,7 +7,7 @@
         "width": 5.0
       },
       "max_iteration_count": 124,
-      "convergence_tolerance": 1e-06,
+      "convergence_tolerance": 1e-6,
       "render_options": {
         "downsample_stride": 1,
         "subpixel_antialiasing": 1

--- a/examples/explore-newton-roots-of-unity-4/params.json
+++ b/examples/explore-newton-roots-of-unity-4/params.json
@@ -7,7 +7,7 @@
         "width": 5.0
       },
       "max_iteration_count": 250,
-      "convergence_tolerance": 1e-06,
+      "convergence_tolerance": 1e-6,
       "render_options": {
         "downsample_stride": 1,
         "subpixel_antialiasing": 2

--- a/examples/render-newton-cosh-minus-one/params.json
+++ b/examples/render-newton-cosh-minus-one/params.json
@@ -7,7 +7,7 @@
         "width": 2.3
       },
       "max_iteration_count": 512,
-      "convergence_tolerance": 1e-06,
+      "convergence_tolerance": 1e-6,
       "render_options": {
         "downsample_stride": 1,
         "subpixel_antialiasing": 3

--- a/examples/render-newton-roots-of-unity-4/params.json
+++ b/examples/render-newton-roots-of-unity-4/params.json
@@ -7,7 +7,7 @@
         "width": 5.0
       },
       "max_iteration_count": 500,
-      "convergence_tolerance": 1e-08,
+      "convergence_tolerance": 1e-8,
       "render_options": {
         "downsample_stride": 1,
         "subpixel_antialiasing": 4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "fractal-renderer-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fractal-renderer-tooling",
+      "devDependencies": {
+        "prettier": "3.8.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fractal-renderer-tooling",
+  "private": true,
+  "description": "Dev tooling (Prettier) for JSON and Markdown formatting. Not a JS package.",
+  "scripts": {
+    "fmt": "prettier --write .",
+    "fmt:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "prettier": "3.8.3"
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}


### PR DESCRIPTION
## Summary

Standardizes JSON and Markdown formatting on Prettier, with CI enforcement and tooling that works for humans, agents, and VS Code on WSL. The repo's README has long claimed Prettier was the formatter, but the config, CI gate, and editor integration were never actually present.

## What's in the box

**Tooling**
- `package.json` with `prettier@3.8.3` pinned exactly, plus `package-lock.json`
- `.prettierrc` — 100-col print width, 2-space indent, LF line endings
- `.prettierignore` — `target/`, `out/`, `node_modules/`, lockfiles, `LICENSE`
- npm scripts: `npm run fmt` (write) and `npm run fmt:check` (verify)

**CI**
- New `prettier` job in `.github/workflows/basic_checks.yml`
- Uses `actions/checkout@v4` + `actions/setup-node@v4` (Node 20) + `npm ci` + `npm run fmt:check`
- Runs in parallel with the existing Rust jobs

**Agent integration**
- New pre-commit hook in `.claude/settings.json` runs `npm run fmt:check` before any `git commit`
- Mirrors the existing `cargo fmt` / `clippy` / `test` / `bench --no-run` gate pattern
- Uses `--check` (not `--write`) so failures are loud — agents fix with `npm run fmt`

**VS Code (workspace, checked in)**
- `.vscode/settings.json` — Prettier as default formatter for JSON, JSONC, Markdown, YAML; `formatOnSave: true`
- `.vscode/extensions.json` — recommends `esbenp.prettier-vscode` and `rust-lang.rust-analyzer`
- `.gitignore` updated to allow these files (previously `.vscode/**/*` was fully ignored)

**Docs**
- `README.md` and `AGENTS.md` updated with the `npm install` / `npm run fmt` workflow and Node ≥14 requirement
- (`CLAUDE.md` is a symlink to `AGENTS.md`, so it's covered too)

## Format-pass diff

Only 4 files needed changes — Prettier flagged a single normalization across all of them:

```diff
- "convergence_tolerance": 1e-06,
+ "convergence_tolerance": 1e-6,
```