### PR TITLE
Interactive "save" now generates "complete" save file.

### DIFF
--- a/docs/gui-unification-roadmap.md
+++ b/docs/gui-unification-roadmap.md
@@ -128,8 +128,8 @@ the CDFs derive from it (not from the keyframes), a color-only re-render is just
 | 2     | Compute / color split                      | ✅ shipped (`4199c23`…`8008aff`) |
 | 3     | Pipeline unification & per-root colors     | ✅ shipped (`56ad860`…`7308de0`) |
 | 4     | Unified `interactive` module + live editor | ✅ shipped (`89f4512`…`ffd733d`) |
-| 5     | Gated, restorable Space-as-save            | ⬜ next (§5)                     |
-| 6     | CLI + cleanup (retire dead code)           | ⬜ §5                            |
+| 5     | Gated, restorable Space-as-save            | ✅ shipped (`8266096`)           |
+| 6     | CLI + cleanup (retire dead code)           | ⬜ next (§5)                     |
 | 7     | Polish                                     | ⬜ §5 (opportunistic)            |
 
 Phases 4 → 6 are sequential; each is a self-contained PR, bisectable and
@@ -447,7 +447,7 @@ architecture makes a color-only re-render trivial (§3.3).
 | PR      | Title                                               | Blast radius                                                       |
 | ------- | --------------------------------------------------- | ------------------------------------------------------------------ |
 | Phase 4 | ✅ Unified `interactive` module + live color editor | New `src/core/interactive/`; `recolorize_only`; `color_dirty` flag |
-| Phase 5 | Gated, restorable Space-as-save                     | Save state machine; full-`FractalParams` serialization             |
+| Phase 5 | ✅ Gated, restorable Space-as-save                  | Save state machine; full-`FractalParams` serialization             |
 | Phase 6 | CLI + cleanup (retire dead code)                    | Delete `color_swatch`, demo example, demo editor module            |
 | Phase 7 | Polish                                              | Contents TBD post-Phase-5 measurement                              |
 
@@ -550,7 +550,39 @@ still work; editing a keyframe recolors the preview live; Newton shows one tab
 per root; `Esc` clears selection (does **not** quit); `Delete` removes a
 non-anchor keyframe; `R` resets view + colors.
 
-### Phase 5 — Gated, restorable Space-as-save
+### Phase 5 — Gated, restorable Space-as-save — ✅ shipped
+
+**Shipped** in `8266096`. Both the interactive Space-save and the headless
+`render` sidecar now write a reloadable, pretty-printed, tagged `FractalParams`
+JSON. Round-trip unit tests (`fractals::common`) guard reloadability per
+variant. Deviations from the plan below, all intentional and documented per
+[the deviations convention](../docs/gui-unification-roadmap.md):
+
+- **`rewrap` is a capturing closure returning a JSON `String`, not
+  `fn(F::Params) -> FractalParams`.** Newton's `Renderable::Params` is
+  `CommonParams`, which does **not** contain the `system`; a plain fn pointer
+  could not reconstruct `FractalParams::NewtonsMethod`. The dispatch site (which
+  picked the concrete system) captures it in a closure and re-injects it.
+  Returning a `String` (built by the `fractals`-layer `*_snapshot_json` helpers)
+  also keeps `core` free of any `FractalParams` reference, preserving the
+  `fractals → core` layering.
+- **The save state machine lives in `PixelGrid` (`render_window.rs`), not
+  `app.rs`.** `PixelGrid` owns the render worker, regulator, pipeline, and file
+  prefix, so the FSM (`SaveState::{Idle, Pending, Rendering}`) and serialization
+  belong there; `app.rs` keeps only the input-lock + "Saving…" overlay and the
+  `request_save` / `is_saving` calls.
+- **The regulator is frozen across the save, not reset-and-cached.** The FSM
+  returns before any regulator call, so the regulator resumes at its exact
+  pre-save state (same "responsiveness restored" effect, no extra field).
+  Forcing `set_speed_optimization_level(0.0)` directly on the fractal both
+  guarantees a full-quality image _and_ restores the user's reference
+  convergence/sampling params in the struct `params()` serializes — required so
+  a snapshot taken after degraded interaction still records full-quality params.
+- **Headless `render` was fixed in the same change** (the §5 note below): its
+  sidecar JSON is now the tagged, reloadable shape too, not the bare inner
+  params.
+
+The original plan follows, for reference.
 
 **Goal:** replace today's fire-and-forget snapshot with the deliberate "publish
 this exact state" flow specified in §7 — input locked, forced to full quality,
@@ -907,19 +939,21 @@ WSL2/XWayland, native Linux, macOS.
   1920×1080 / 2K if it feels laggy; debounce or downsample-while-dragging falls
   to Phase 7.
 
-**Saved JSON isn't reloadable**
+**Saved JSON isn't reloadable** — ✅ resolved (Phase 5)
 
 - **Phase:** 5
-- **Mitigation:** the snapshot must serialize the tagged `FractalParams`, not
-  the bare inner params (see the §5 Phase-5 design wrinkle). Verify by reloading
-  the saved file via `explore <saved.json>` and confirming the preview matches
-  the saved PNG (§7.3).
+- **Mitigation:** the snapshot serializes the tagged `FractalParams` (via the
+  `*_snapshot_json` closures), not the bare inner params. Newton's `system` is
+  re-injected at the dispatch site (it is absent from `CommonParams`).
+  Round-trip unit tests in `fractals::common` assert each variant reloads, and
+  the system is asserted preserved.
 
-**Save flow races with an in-flight interactive render**
+**Save flow races with an in-flight interactive render** — ✅ resolved (Phase 5)
 
 - **Phase:** 5
-- **Mitigation:** the save state machine locks input and forces a fresh
-  full-quality render before writing; it does not snapshot a degraded buffer.
+- **Mitigation:** the `SaveState` machine waits for the worker to be free, then
+  forces a fresh full-quality render before writing; it never snapshots a
+  degraded buffer.
 
 **Tab count drifts from `color_maps.len()`**
 
@@ -1028,8 +1062,8 @@ These do not block any phase but should be decided as the relevant phase lands.
    [src/fractals/driven_damped_pendulum.rs](../src/fractals/driven_damped_pendulum.rs),
    and [src/fractals/newtons_method.rs](../src/fractals/newtons_method.rs) to see
    how each embeds `ColorPalette` and implements `Renderable` / `FieldKernel`.
-7. Confirm `cargo test` passes on `main`. Start Phase 4 (§5). Make a small first
-   commit (the module reorg, no behavior change) to keep the diff reviewable.
+7. Confirm `cargo test` passes on `main`. Phases 4 and 5 have shipped; the next
+   unstarted PR is Phase 6 (CLI + cleanup, §5). Keep each PR bisectable.
 8. Re-read §5 for that phase's detail, §6/§7 for the widget and save specs, and
    §10 for phase-specific risks.
 

--- a/src/cli/explore.rs
+++ b/src/cli/explore.rs
@@ -2,7 +2,10 @@ use std::any::type_name;
 
 use crate::{
     core::{file_io::FilePrefix, interactive},
-    fractals::{common::FractalParams, newtons_method},
+    fractals::{
+        common::{FractalParams, ddp_snapshot_json, julia_snapshot_json, mandelbrot_snapshot_json},
+        newtons_method,
+    },
 };
 
 /**
@@ -21,6 +24,7 @@ pub fn explore_fractal(params: &FractalParams, mut file_prefix: FilePrefix) -> e
                 file_prefix,
                 inner_params.image_specification,
                 (**inner_params).clone(),
+                mandelbrot_snapshot_json,
             )
         }
 
@@ -30,6 +34,7 @@ pub fn explore_fractal(params: &FractalParams, mut file_prefix: FilePrefix) -> e
                 file_prefix,
                 inner_params.image_specification,
                 (**inner_params).clone(),
+                julia_snapshot_json,
             )
         }
 
@@ -39,6 +44,7 @@ pub fn explore_fractal(params: &FractalParams, mut file_prefix: FilePrefix) -> e
                 file_prefix,
                 inner_params.image_specification,
                 (**inner_params).clone(),
+                ddp_snapshot_json,
             )
         }
 

--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -1,7 +1,9 @@
 use crate::core::image_utils;
 use crate::fractals::newtons_method::render_newtons_method;
 use crate::fractals::{
-    barnsley_fern::render_barnsley_fern, common::FractalParams, serpinsky::render_serpinsky,
+    barnsley_fern::render_barnsley_fern,
+    common::{FractalParams, ddp_snapshot_json, julia_snapshot_json, mandelbrot_snapshot_json},
+    serpinsky::render_serpinsky,
 };
 
 use crate::core::file_io::FilePrefix;
@@ -13,15 +15,19 @@ pub fn render_fractal(
     match params {
         FractalParams::Mandelbrot(inner_params) => {
             file_prefix.create_and_step_into_sub_directory("mandelbrot");
-            image_utils::render((**inner_params).clone(), file_prefix)
+            image_utils::render(
+                (**inner_params).clone(),
+                file_prefix,
+                mandelbrot_snapshot_json,
+            )
         }
         FractalParams::Julia(inner_params) => {
             file_prefix.create_and_step_into_sub_directory("julia");
-            image_utils::render((**inner_params).clone(), file_prefix)
+            image_utils::render((**inner_params).clone(), file_prefix, julia_snapshot_json)
         }
         FractalParams::DrivenDampedPendulum(inner_params) => {
             file_prefix.create_and_step_into_sub_directory("driven_damped_pendulum");
-            image_utils::render((**inner_params).clone(), file_prefix)
+            image_utils::render((**inner_params).clone(), file_prefix, ddp_snapshot_json)
         }
         FractalParams::BarnsleyFern(inner_params) => {
             file_prefix.create_and_step_into_sub_directory("barnsley_fern");

--- a/src/core/file_io.rs
+++ b/src/core/file_io.rs
@@ -51,7 +51,25 @@ where
 {
     let serialized_data = serde_json::to_string(data)
         .unwrap_or_else(|_| panic!("ERROR:  Unable to serialize data: {:?}", data));
-    std::fs::write(&filename, serialized_data)
+    write_file_or_panic(filename, &serialized_data);
+}
+
+/// Serialize `data` to pretty-printed JSON, panicking with a descriptive
+/// message on failure. Mirrors `serialize_to_json_or_panic`'s policy, but
+/// returns the string (for callers that wrap the value first) and uses the
+/// human-readable multi-line layout suited to reloadable snapshot files.
+pub fn to_pretty_json_or_panic<T>(data: &T) -> String
+where
+    T: Serialize + Debug,
+{
+    serde_json::to_string_pretty(data)
+        .unwrap_or_else(|_| panic!("ERROR:  Unable to serialize data: {:?}", data))
+}
+
+/// Write `contents` to `filename`, panicking with a descriptive message on
+/// IO failure.
+pub fn write_file_or_panic(filename: std::path::PathBuf, contents: &str) {
+    std::fs::write(&filename, contents)
         .unwrap_or_else(|_| panic!("ERROR:  Unable to write file: {:?}", filename));
 }
 

--- a/src/core/image_utils.rs
+++ b/src/core/image_utils.rs
@@ -11,7 +11,7 @@ use crate::core::field_iteration::FieldKernel;
 use crate::core::interpolation::Interpolator;
 use crate::core::render_pipeline::RenderingPipeline;
 
-use super::file_io::{FilePrefix, serialize_to_json_or_panic};
+use super::file_io::{FilePrefix, write_file_or_panic};
 use super::stopwatch::Stopwatch;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -268,9 +268,15 @@ pub trait Renderable: Sync + Send + SpeedOptimizer + FieldKernel {
 
 /// Render a fractal to a PNG file (and a sibling JSON / diagnostics file).
 /// Drives the new `RenderingPipeline` at the user's full sampling level.
+///
+/// `snapshot_json` wraps the renderable's inner params back into a reloadable,
+/// tagged `FractalParams` JSON string. It is supplied by the caller (the CLI
+/// dispatch knows the concrete variant) so this `core` function stays
+/// independent of the `fractals::FractalParams` enum.
 pub fn render<T: Renderable + 'static>(
     renderable: T,
     file_prefix: FilePrefix,
+    snapshot_json: impl Fn(&T::Params) -> String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut stopwatch = Stopwatch::new("Render Stopwatch".to_owned());
 
@@ -281,9 +287,9 @@ pub fn render<T: Renderable + 'static>(
     let histogram_max_value = renderable.histogram_max_value();
     let lookup_table_count = renderable.lookup_table_count();
 
-    serialize_to_json_or_panic(
+    write_file_or_panic(
         file_prefix.full_path_with_suffix(".json"),
-        renderable.params(),
+        &snapshot_json(renderable.params()),
     );
     stopwatch.record_split("basic setup".to_owned());
 
@@ -301,12 +307,7 @@ pub fn render<T: Renderable + 'static>(
     pipeline.render(&mut color_image, cached_sampling_level);
     stopwatch.record_split("render pipeline".to_owned());
 
-    let mut imgbuf = image::ImageBuffer::new(spec.resolution[0], spec.resolution[1]);
-    let width = color_image.size[0];
-    for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {
-        let c = color_image.pixels[(y as usize) * width + (x as usize)];
-        *pixel = image::Rgb([c.r(), c.g(), c.b()]);
-    }
+    let imgbuf = color_image_to_rgb8(&color_image);
     stopwatch.record_split("copy into image buffer".to_owned());
     write_image_to_file_or_panic(file_prefix.full_path_with_suffix(".png"), |f| {
         imgbuf.save(f)
@@ -511,6 +512,19 @@ impl SubpixelGridMask {
     pub fn count_ones(&self) -> u32 {
         self.bitmask.count_ones()
     }
+}
+
+/// Convert an `egui::ColorImage` (RGBA, row-major) into an RGB8 image buffer
+/// ready to encode to a PNG. Drops the alpha channel.
+pub fn color_image_to_rgb8(color_image: &ColorImage) -> image::RgbImage {
+    let width = color_image.size[0];
+    let height = color_image.size[1];
+    let mut imgbuf = image::ImageBuffer::new(width as u32, height as u32);
+    for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {
+        let c = color_image.pixels[(y as usize) * width + (x as usize)];
+        *pixel = image::Rgb([c.r(), c.g(), c.b()]);
+    }
+    imgbuf
 }
 
 pub fn write_image_to_file_or_panic<F, T, E>(filename: std::path::PathBuf, save_lambda: F)

--- a/src/core/interactive/app.rs
+++ b/src/core/interactive/app.rs
@@ -14,7 +14,7 @@ use crate::core::{
     file_io::FilePrefix,
     image_utils::{ImageSpecification, PixelMapper, Renderable},
     interactive::editor::{EditorState, delete_keyframe, show_palette_editor},
-    render_window::{PixelGrid, RenderWindow},
+    render_window::{PixelGrid, RenderWindow, SnapshotSerializer},
     stopwatch::Stopwatch,
     view_control::{
         CenterCommand, CenterTargetCommand, CenterVelocityCommand, ScalarDirection, ViewControl,
@@ -148,6 +148,7 @@ impl<F: Renderable + Send + Sync + 'static> FractalApp<F> {
         file_prefix: FilePrefix,
         image_specification: ImageSpecification,
         renderer: F,
+        serialize_snapshot: SnapshotSerializer<F>,
     ) -> Self {
         // Match the color editor's theme: black panel fill + no separator
         // stroke avoids sub-pixel gap artifacts between panels at fractional
@@ -164,6 +165,7 @@ impl<F: Renderable + Send + Sync + 'static> FractalApp<F> {
             file_prefix,
             ViewControl::new(time, image_specification),
             renderer,
+            serialize_snapshot,
         );
 
         let [res_w, res_h] = image_specification.resolution;
@@ -223,6 +225,12 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let ctx = ui.ctx().clone();
+        // While a snapshot is saving, all interactive input is suppressed
+        // (§7.2 of the roadmap) — the view, palette, and selection are frozen
+        // until the gated full-quality render completes. Quit is *not*
+        // suppressed.
+        let saving = self.render_window.is_saving();
+
         // Quit: `Q`, or `Ctrl+C` (terminal default). `Esc` no longer quits —
         // it clears the keyframe selection instead.
         if ctx.input(|i| i.key_pressed(Key::Q) || (i.modifiers.ctrl && i.key_pressed(Key::C))) {
@@ -230,36 +238,45 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
             return;
         }
 
-        // `Esc` clears the keyframe selection (no-op when nothing selected).
-        if ctx.input(|i| i.key_pressed(Key::Escape)) {
-            self.editor_state.selected_keyframe = None;
+        // `Space` initiates a gated, restorable save. Debounced: a second press
+        // while a save is already in flight is ignored.
+        if !saving && ctx.input(|i| i.key_pressed(Key::Space)) {
+            self.render_window.request_save();
         }
 
-        // `Delete` removes the selected keyframe (no-op on the 0.0 / 1.0
-        // anchors), then triggers a color-only re-render.
-        if ctx.input(|i| i.key_pressed(Key::Delete))
-            && let Some(selected) = self.editor_state.selected_keyframe
-        {
-            let active = self.editor_state.active_color_map;
-            let mut deleted = false;
+        // Keyframe-editor keys are inert while saving.
+        if !saving {
+            // `Esc` clears the keyframe selection (no-op when nothing selected).
+            if ctx.input(|i| i.key_pressed(Key::Escape)) {
+                self.editor_state.selected_keyframe = None;
+            }
+
+            // `Delete` removes the selected keyframe (no-op on the 0.0 / 1.0
+            // anchors), then triggers a color-only re-render.
+            if ctx.input(|i| i.key_pressed(Key::Delete))
+                && let Some(selected) = self.editor_state.selected_keyframe
             {
-                let mut palette = self.render_window.palette().lock().unwrap();
-                if active < palette.color_maps.len() {
-                    deleted = delete_keyframe(&mut palette.color_maps[active], selected);
+                let active = self.editor_state.active_color_map;
+                let mut deleted = false;
+                {
+                    let mut palette = self.render_window.palette().lock().unwrap();
+                    if active < palette.color_maps.len() {
+                        deleted = delete_keyframe(&mut palette.color_maps[active], selected);
+                    }
+                }
+                if deleted {
+                    self.editor_state.selected_keyframe = None;
+                    self.render_window.mark_color_dirty();
                 }
             }
-            if deleted {
-                self.editor_state.selected_keyframe = None;
-                self.render_window.mark_color_dirty();
-            }
-        }
 
-        // `R` resets the view and the color palette to their initial state.
-        // Edge-triggered (like Space): holding the key should reset once, not
-        // re-clone the palette and re-mark the preview dirty every frame.
-        if ctx.input(|i| i.key_pressed(Key::R)) {
-            self.render_window.reset();
-            self.editor_state.selected_keyframe = None;
+            // `R` resets the view and the color palette to their initial state.
+            // Edge-triggered (like Space): holding the key should reset once,
+            // not re-clone the palette and re-mark the preview dirty every frame.
+            if ctx.input(|i| i.key_pressed(Key::R)) {
+                self.render_window.reset();
+                self.editor_state.selected_keyframe = None;
+            }
         }
 
         let mut palette_changed = false;
@@ -273,8 +290,12 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
                     .inner_margin(egui::Margin::symmetric(8, 4)),
             )
             .show_inside(ui, |ui| {
-                let mut palette = self.render_window.palette().lock().unwrap();
-                palette_changed = show_palette_editor(&mut palette, ui, &mut self.editor_state);
+                // Disabled while saving so widget interactions cannot mutate
+                // the palette mid-snapshot.
+                ui.add_enabled_ui(!saving, |ui| {
+                    let mut palette = self.render_window.palette().lock().unwrap();
+                    palette_changed = show_palette_editor(&mut palette, ui, &mut self.editor_state);
+                });
             });
         if palette_changed {
             self.render_window.mark_color_dirty();
@@ -286,12 +307,19 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
             .show_inside(ui, |ui| self.show_preview(ui))
             .inner;
 
-        let image_specification = *self.render_window.image_specification();
-        let center_command = match click {
-            Some((pos, rect)) => click_to_center_command(pos, rect, &image_specification),
-            None => keyboard_center_command(&ctx),
+        // Suppress view commands while saving (Idle pan, zero zoom). The save
+        // FSM still advances each `update`, and the frozen regulator resumes
+        // afterward.
+        let (center_command, zoom_command) = if saving {
+            (CenterCommand::Idle(), ZoomVelocityCommand::zero())
+        } else {
+            let image_specification = *self.render_window.image_specification();
+            let center_command = match click {
+                Some((pos, rect)) => click_to_center_command(pos, rect, &image_specification),
+                None => keyboard_center_command(&ctx),
+            };
+            (center_command, zoom_command_from_input(&ctx))
         };
-        let zoom_command = zoom_command_from_input(&ctx);
 
         let time = self.stopwatch.total_elapsed_seconds();
         let new_buffer_ready = self
@@ -304,8 +332,9 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
                 .set(self.display_image.clone(), egui::TextureOptions::LINEAR);
         }
 
-        if ctx.input(|i| i.key_pressed(Key::Space)) {
-            self.render_window.render_to_file();
+        // "Saving snapshot…" overlay while the gated render is in flight.
+        if self.render_window.is_saving() {
+            draw_saving_overlay(&ctx);
         }
 
         // Keep the UI ticking while work is in flight or the user is driving
@@ -314,9 +343,31 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
         let active = any_control_key_held(&ctx)
             || self.render_window.render_task_is_busy()
             || self.render_window.redraw_required()
-            || self.render_window.adaptive_rendering_required();
+            || self.render_window.adaptive_rendering_required()
+            || self.render_window.is_saving();
         ctx.request_repaint_after(if active { ACTIVE_TICK } else { IDLE_TICK });
     }
+}
+
+/// Paint a translucent, centered "Saving snapshot…" overlay while a gated save
+/// render is in flight. Drawn as a foreground `Area`, so it sits above the
+/// preview and editor without disturbing the §4.1 black-fill panel layout.
+fn draw_saving_overlay(ctx: &egui::Context) {
+    egui::Area::new(egui::Id::new("save_overlay"))
+        .anchor(egui::Align2::CENTER_CENTER, egui::Vec2::ZERO)
+        .order(egui::Order::Foreground)
+        .show(ctx, |ui| {
+            Frame::NONE
+                .fill(Color32::from_black_alpha(220))
+                .inner_margin(egui::Margin::same(16))
+                .show(ui, |ui| {
+                    ui.label(
+                        egui::RichText::new("Saving snapshot…")
+                            .size(20.0)
+                            .color(Color32::WHITE),
+                    );
+                });
+        });
 }
 
 /// Open the interactive fractal explorer window.
@@ -332,10 +383,15 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
 /// - `Esc`: clear the keyframe selection. `Delete`: remove the selected
 ///   keyframe.
 /// - `Q` / `Ctrl+C`: exit.
+///
+/// `serialize_snapshot` wraps the fractal's inner params back into a reloadable,
+/// tagged `FractalParams` JSON string for the Space-as-save snapshot; the
+/// dispatch site that selected the concrete `F` supplies it.
 pub fn explore<F: Renderable + Send + Sync + 'static>(
     file_prefix: FilePrefix,
     image_specification: ImageSpecification,
     renderer: F,
+    serialize_snapshot: impl Fn(&F::Params) -> String + 'static,
 ) -> eframe::Result<()> {
     let [res_w, res_h] = image_specification.resolution;
     let options = wgpu_native_options(
@@ -351,6 +407,7 @@ pub fn explore<F: Renderable + Send + Sync + 'static>(
                 file_prefix,
                 image_specification,
                 renderer,
+                Box::new(serialize_snapshot),
             )))
         }),
     )

--- a/src/core/interactive/app.rs
+++ b/src/core/interactive/app.rs
@@ -229,7 +229,7 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
         // (§7.2 of the roadmap) — the view, palette, and selection are frozen
         // until the gated full-quality render completes. Quit is *not*
         // suppressed.
-        let saving = self.render_window.is_saving();
+        let mut saving = self.render_window.is_saving();
 
         // Quit: `Q`, or `Ctrl+C` (terminal default). `Esc` no longer quits —
         // it clears the keyframe selection instead.
@@ -242,6 +242,10 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
         // while a save is already in flight is ignored.
         if !saving && ctx.input(|i| i.key_pressed(Key::Space)) {
             self.render_window.request_save();
+            // Suppress the rest of this frame's input immediately, so a
+            // simultaneous slider drag or keypress on the press frame can't
+            // mutate the state that is about to be snapshotted.
+            saving = true;
         }
 
         // Keyframe-editor keys are inert while saving.

--- a/src/core/interactive/app.rs
+++ b/src/core/interactive/app.rs
@@ -34,12 +34,12 @@ const FAST_PAN_RATE: f64 = 2.5 * PAN_RATE;
 /// Minimum repaint period while the user is interacting or a render is in
 /// flight. 100 Hz is faster than any common vsync cap, so the actual cadence
 /// is still limited by the display refresh rate.
-const ACTIVE_TICK: Duration = Duration::from_millis(10);
+const ACTIVE_TICK_DURATION: Duration = Duration::from_millis(10);
 
 /// Defensive repaint period when the UI is otherwise idle. Keeps the app
 /// responsive to silently-dropped resize / input events on WSL/XWayland
 /// (see §4.2 of https://github.com/MatthewPeterKelly/fractal-renderer/blob/planning/gui-roadmap/docs/gui-unification-roadmap.md).
-const IDLE_TICK: Duration = Duration::from_millis(100);
+const IDLE_TICK_DURATION: Duration = Duration::from_millis(100);
 
 /// Default width of the color-editor side panel, in logical pixels.
 const EDITOR_PANEL_WIDTH: f32 = 260.0;
@@ -225,21 +225,20 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let ctx = ui.ctx().clone();
-        // While a snapshot is saving, all interactive input is suppressed
-        // (§7.2 of the roadmap) — the view, palette, and selection are frozen
-        // until the gated full-quality render completes. Quit is *not*
-        // suppressed.
+        // While a snapshot is saving, all interactive input is suppressed.
+        // The view, palette, and selection are frozen
+        // until the gated full-quality render completes.
+        // Quit is *not* suppressed.
         let mut saving = self.render_window.is_saving();
 
-        // Quit: `Q`, or `Ctrl+C` (terminal default). `Esc` no longer quits —
-        // it clears the keyframe selection instead.
+        // Quit: `Q`, or `Ctrl+C` (terminal default).
         if ctx.input(|i| i.key_pressed(Key::Q) || (i.modifiers.ctrl && i.key_pressed(Key::C))) {
             ctx.send_viewport_cmd(egui::ViewportCommand::Close);
             return;
         }
 
-        // `Space` initiates a gated, restorable save. Debounced: a second press
-        // while a save is already in flight is ignored.
+        // `Space` initiates a gated, restorable save.
+        // Debounced: a second press while a save is already in flight is ignored.
         if !saving && ctx.input(|i| i.key_pressed(Key::Space)) {
             self.render_window.request_save();
             // Suppress the rest of this frame's input immediately, so a
@@ -349,7 +348,11 @@ impl<F: Renderable + 'static> eframe::App for FractalApp<F> {
             || self.render_window.redraw_required()
             || self.render_window.adaptive_rendering_required()
             || self.render_window.is_saving();
-        ctx.request_repaint_after(if active { ACTIVE_TICK } else { IDLE_TICK });
+        ctx.request_repaint_after(if active {
+            ACTIVE_TICK_DURATION
+        } else {
+            IDLE_TICK_DURATION
+        });
     }
 }
 

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -9,9 +9,10 @@ use crate::core::color_map::ColorPalette;
 use crate::core::render_quality_fsm::AdaptiveOptimizationRegulator;
 
 use super::{
-    file_io::{FilePrefix, date_time_string, serialize_to_json_or_panic},
+    file_io::{FilePrefix, date_time_string, write_file_or_panic},
     image_utils::{
-        ImageSpecification, Renderable, field_upsample_factor, write_image_to_file_or_panic,
+        ImageSpecification, Renderable, color_image_to_rgb8, field_upsample_factor,
+        write_image_to_file_or_panic,
     },
     render_pipeline::RenderingPipeline,
     view_control::{CenterCommand, CenterTargetCommand, ViewControl, ZoomVelocityCommand},
@@ -48,12 +49,29 @@ pub trait RenderWindow {
     ///   resolution. Its row-major pixel buffer is overwritten in place with
     ///   the latest fractal colors.
     fn draw(&self, image: &mut ColorImage);
-
-    /// Saves the current rendered content to a file.
-    ///
-    /// This may also serialize additional data such as rendering parameters.
-    fn render_to_file(&self);
 }
+
+/// State of the gated Space-as-save flow (Phase 5 of the GUI roadmap): a
+/// deliberate "publish this exact state" action that forces a full-quality
+/// render before writing a reloadable params JSON + a matching PNG.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SaveState {
+    /// No save in progress.
+    Idle,
+    /// Space pressed; waiting for the render worker to be free so a forced
+    /// full-quality render can be launched.
+    Pending,
+    /// A full-quality save render is in flight; the snapshot is written to
+    /// disk once it completes.
+    Rendering,
+}
+
+/// Boxed closure that wraps a fractal's inner params into a reloadable, tagged
+/// `FractalParams` JSON string for the Space-as-save snapshot. It is `dyn`
+/// (off the render hot path) so `core` need not name the
+/// `fractals::FractalParams` enum; the dispatch site that picked the concrete
+/// variant supplies it.
+pub type SnapshotSerializer<F> = Box<dyn Fn(&<F as Renderable>::Params) -> String>;
 
 /// Generic `RenderWindow` implementation backed by a `RenderingPipeline`.
 /// All "solve by pixel" fractals run through it. Per-(sub)pixel dispatch is
@@ -115,6 +133,15 @@ pub struct PixelGrid<F: Renderable> {
 
     // Whether a render has ever been launched on this `PixelGrid`.
     has_started_rendering: bool,
+
+    // Serializes the current fractal params into a reloadable, tagged
+    // `FractalParams` JSON string for the Space-as-save snapshot. Boxed so
+    // `core` need not depend on the `fractals::FractalParams` enum; supplied
+    // by the dispatch site that knows the concrete variant.
+    serialize_snapshot: SnapshotSerializer<F>,
+
+    // Drives the gated Space-as-save flow (see `SaveState`).
+    save_state: SaveState,
 }
 
 const TARGET_RENDER_FRAMES_PER_SECOND: f64 = 24.0;
@@ -125,7 +152,17 @@ where
 {
     /// Construct a `PixelGrid` around the given fractal. Allocates the
     /// pipeline's reusable buffers at the user's full sampling level.
-    pub fn new(time: f64, file_prefix: FilePrefix, view_control: ViewControl, renderer: F) -> Self {
+    ///
+    /// `serialize_snapshot` wraps the fractal's inner params back into a
+    /// reloadable, tagged `FractalParams` JSON string for the Space-as-save
+    /// snapshot (kept out of `core` so the layering stays `fractals → core`).
+    pub fn new(
+        time: f64,
+        file_prefix: FilePrefix,
+        view_control: ViewControl,
+        renderer: F,
+        serialize_snapshot: SnapshotSerializer<F>,
+    ) -> Self {
         let resolution = view_control.image_specification().resolution;
         let center_command = CenterCommand::Target(CenterTargetCommand {
             view_center: view_control.image_specification().center,
@@ -158,6 +195,8 @@ where
             initial_color_palette,
             last_sampling_level: Arc::new(AtomicI32::new(0)),
             has_started_rendering: false,
+            serialize_snapshot,
+            save_state: SaveState::Idle,
             adaptive_quality_regulator: AdaptiveOptimizationRegulator::new(
                 1.0 / TARGET_RENDER_FRAMES_PER_SECOND,
             ),
@@ -195,6 +234,45 @@ where
     /// re-render. Drained by the next `update`.
     pub fn mark_color_dirty(&self) {
         self.color_dirty.store(true, Ordering::Release);
+    }
+
+    /// Whether a gated Space-as-save snapshot is currently being produced.
+    /// While true, the interactive app locks input and shows a "Saving…"
+    /// overlay.
+    pub fn is_saving(&self) -> bool {
+        self.save_state != SaveState::Idle
+    }
+
+    /// Begin a gated Space-as-save: the next `update` calls force a
+    /// full-quality render and then write a reloadable params JSON + a
+    /// matching PNG. No-op if a save is already in progress (this debounces a
+    /// double Space press).
+    pub fn request_save(&mut self) {
+        if self.save_state == SaveState::Idle {
+            self.save_state = SaveState::Pending;
+        }
+    }
+
+    /// Serialize the current (full-quality, palette- and view-synced) fractal
+    /// params to a timestamped reloadable JSON and write the on-screen buffer
+    /// to a matching PNG. Called once the forced save render completes.
+    fn write_snapshot(&self) {
+        let datetime = date_time_string();
+        let json = {
+            let pipeline = self.pipeline.lock().unwrap();
+            (self.serialize_snapshot)(pipeline.fractal().params())
+        };
+        write_file_or_panic(
+            self.file_prefix
+                .full_path_with_suffix(&format!("_{datetime}.json")),
+            &json,
+        );
+        let imgbuf = color_image_to_rgb8(&self.display_buffer.lock().unwrap());
+        write_image_to_file_or_panic(
+            self.file_prefix
+                .full_path_with_suffix(&format!("_{datetime}.png")),
+            |f| imgbuf.save(f),
+        );
     }
 
     /// Spawn a background render on the pipeline. The pipeline's mutex
@@ -281,6 +359,47 @@ where
         // (2) the adaptive quality regulator reports that the render quality needs to be modified
         let user_interaction = self.view_control.update(time, center_command, zoom_command);
 
+        // Gated Space-as-save flow. While active it takes over scheduling
+        // entirely and never calls the adaptive regulator, so the regulator
+        // is *frozen* across the save: interaction resumes afterward at its
+        // exact pre-save responsiveness (rather than the roadmap's
+        // reset-and-cache, which is equivalent in effect). `view_control` is
+        // still advanced above each frame, so resuming never sees a time jump.
+        match self.save_state {
+            SaveState::Pending => {
+                // Wait for any in-flight render to finish, then launch a
+                // forced full-quality save render. Forcing level 0.0 both
+                // guarantees image fidelity *and* restores the user's
+                // reference params, so the serialized params are full-quality
+                // rather than whatever degraded state interaction left behind.
+                if !self.render_task_is_busy.swap(true, Ordering::Acquire) {
+                    self.redraw_required.store(false, Ordering::Release);
+                    self.pipeline
+                        .lock()
+                        .unwrap()
+                        .fractal_mut()
+                        .set_speed_optimization_level(0.0, &self.speed_optimizer_cache);
+                    self.has_started_rendering = true;
+                    self.render();
+                    self.save_state = SaveState::Rendering;
+                }
+                return false;
+            }
+            SaveState::Rendering => {
+                if self.redraw_required.load(Ordering::Acquire)
+                    && !self.render_task_is_busy.load(Ordering::Acquire)
+                {
+                    self.write_snapshot();
+                    self.save_state = SaveState::Idle;
+                    // Report the completed full-quality frame so the app
+                    // uploads it to the preview texture.
+                    return true;
+                }
+                return false;
+            }
+            SaveState::Idle => {}
+        }
+
         // If redraw is required, it tells us that the previous rendering operation has
         // completed. Capture this timing *before* possibly launching a new render, so that
         // the measured period is associated with the correct command.
@@ -344,33 +463,6 @@ where
         let display_buffer = self.display_buffer.lock().unwrap();
         image.pixels.copy_from_slice(&display_buffer.pixels);
         self.redraw_required.store(false, Ordering::Release);
-    }
-
-    fn render_to_file(&self) {
-        let datetime = date_time_string();
-
-        serialize_to_json_or_panic(
-            self.file_prefix
-                .full_path_with_suffix(&format!("_{datetime}.json")),
-            &self.image_specification(),
-        );
-
-        let resolution = self.image_specification().resolution;
-        let mut imgbuf = image::ImageBuffer::new(resolution[0], resolution[1]);
-        {
-            let display_buffer = self.display_buffer.lock().unwrap();
-            let width = display_buffer.size[0];
-            for (x, y, pixel) in imgbuf.enumerate_pixels_mut() {
-                let c = display_buffer.pixels[(y as usize) * width + (x as usize)];
-                *pixel = image::Rgb([c.r(), c.g(), c.b()]);
-            }
-        }
-
-        write_image_to_file_or_panic(
-            self.file_prefix
-                .full_path_with_suffix(&format!("_{datetime}.png")),
-            |f| imgbuf.save(f),
-        );
     }
 }
 

--- a/src/core/render_window.rs
+++ b/src/core/render_window.rs
@@ -359,12 +359,27 @@ where
         // (2) the adaptive quality regulator reports that the render quality needs to be modified
         let user_interaction = self.view_control.update(time, center_command, zoom_command);
 
-        // Gated Space-as-save flow. While active it takes over scheduling
-        // entirely and never calls the adaptive regulator, so the regulator
-        // is *frozen* across the save: interaction resumes afterward at its
-        // exact pre-save responsiveness (rather than the roadmap's
-        // reset-and-cache, which is equivalent in effect). `view_control` is
-        // still advanced above each frame, so resuming never sees a time jump.
+        // If a render completed, close out its timing *before* anything else —
+        // including the save flow — can clear the flag or launch the next
+        // render. Doing it here (rather than after the save match) ensures a
+        // render that finishes just as a save begins is still recorded, so the
+        // regulator's `render_start_time` is never left dangling across the
+        // save. Capturing the period before launching also keeps it associated
+        // with the correct command.
+        let redraw_required = self.redraw_required.load(Ordering::Acquire);
+        if redraw_required {
+            self.adaptive_quality_regulator.finish_rendering(time);
+        }
+
+        // Gated Space-as-save flow. While active it takes over scheduling and
+        // never *launches* a regulator-driven render, so the regulator's
+        // mode/command stay frozen across the save: interaction resumes
+        // afterward at its exact pre-save responsiveness (rather than the
+        // roadmap's reset-and-cache, which is equivalent in effect). The
+        // `finish_rendering` above still runs, but the save render bypasses
+        // `begin_rendering`, so once the pre-save render is closed out it is a
+        // no-op. `view_control` is also advanced above, so resuming never sees
+        // a time jump.
         match self.save_state {
             SaveState::Pending => {
                 // Wait for any in-flight render to finish, then launch a
@@ -374,6 +389,12 @@ where
                 // rather than whatever degraded state interaction left behind.
                 if !self.render_task_is_busy.swap(true, Ordering::Acquire) {
                     self.redraw_required.store(false, Ordering::Release);
+                    // The save render is a full render: it clones the current
+                    // (possibly just-edited) palette into the fractal, so it
+                    // already satisfies any pending color edit. Clear the flag
+                    // so a redundant recolorize doesn't fire after the save
+                    // (mirrors the full-render path below).
+                    self.color_dirty.store(false, Ordering::Release);
                     self.pipeline
                         .lock()
                         .unwrap()
@@ -386,9 +407,7 @@ where
                 return false;
             }
             SaveState::Rendering => {
-                if self.redraw_required.load(Ordering::Acquire)
-                    && !self.render_task_is_busy.load(Ordering::Acquire)
-                {
+                if redraw_required && !self.render_task_is_busy.load(Ordering::Acquire) {
                     self.write_snapshot();
                     self.save_state = SaveState::Idle;
                     // Report the completed full-quality frame so the app
@@ -398,14 +417,6 @@ where
                 return false;
             }
             SaveState::Idle => {}
-        }
-
-        // If redraw is required, it tells us that the previous rendering operation has
-        // completed. Capture this timing *before* possibly launching a new render, so that
-        // the measured period is associated with the correct command.
-        let redraw_required = self.redraw_required.load(Ordering::Acquire);
-        if redraw_required {
-            self.adaptive_quality_regulator.finish_rendering(time);
         }
 
         let render_required = self

--- a/src/fractals/common.rs
+++ b/src/fractals/common.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 
+use crate::core::file_io::to_pretty_json_or_panic;
+
 use super::{
-    barnsley_fern::BarnsleyFernParams, driven_damped_pendulum::DrivenDampedPendulumParams,
-    julia::JuliaParams, mandelbrot::MandelbrotParams, newtons_method::NewtonsMethodParams,
+    barnsley_fern::BarnsleyFernParams,
+    driven_damped_pendulum::DrivenDampedPendulumParams,
+    julia::JuliaParams,
+    mandelbrot::MandelbrotParams,
+    newtons_method::{CommonParams, NewtonsMethodParams, SystemType},
     serpinsky::SerpinskyParams,
 };
 
@@ -14,6 +19,40 @@ pub enum FractalParams {
     BarnsleyFern(Box<BarnsleyFernParams>),
     Serpinsky(Box<SerpinskyParams>),
     NewtonsMethod(Box<NewtonsMethodParams>),
+}
+
+/// Serialize Mandelbrot params as a reloadable, pretty-printed tagged
+/// `FractalParams` snapshot (the `{"Mandelbrot": …}` shape `explore` /
+/// `render` accept as input).
+pub fn mandelbrot_snapshot_json(params: &MandelbrotParams) -> String {
+    to_pretty_json_or_panic(&FractalParams::Mandelbrot(Box::new(params.clone())))
+}
+
+/// Serialize Julia params as a reloadable, pretty-printed tagged
+/// `FractalParams` snapshot.
+pub fn julia_snapshot_json(params: &JuliaParams) -> String {
+    to_pretty_json_or_panic(&FractalParams::Julia(Box::new(params.clone())))
+}
+
+/// Serialize driven-damped-pendulum params as a reloadable, pretty-printed
+/// tagged `FractalParams` snapshot.
+pub fn ddp_snapshot_json(params: &DrivenDampedPendulumParams) -> String {
+    to_pretty_json_or_panic(&FractalParams::DrivenDampedPendulum(Box::new(
+        params.clone(),
+    )))
+}
+
+/// Serialize Newton's-method params as a reloadable, pretty-printed tagged
+/// `FractalParams` snapshot. The `system` must be supplied separately because
+/// it is not part of the renderer's `Renderable::Params` (`CommonParams`); the
+/// dispatch site that picked the concrete system threads it back in here.
+pub fn newton_snapshot_json(system: &SystemType, params: &CommonParams) -> String {
+    to_pretty_json_or_panic(&FractalParams::NewtonsMethod(Box::new(
+        NewtonsMethodParams {
+            params: params.clone(),
+            system: system.clone(),
+        },
+    )))
 }
 
 #[cfg(test)]
@@ -60,6 +99,67 @@ mod tests {
         assert!(
             result.is_err(),
             "expected parse failure for Newton-shaped color in Mandelbrot params"
+        );
+    }
+
+    /// Parse a snapshot string and assert it is a valid, idempotently
+    /// round-tripping `FractalParams` carrying the expected top-level tag.
+    /// Idempotence (re-serializing the reparsed value reproduces the same
+    /// JSON tree) sidesteps integer-vs-float `Value` mismatches that a raw
+    /// comparison against hand-written input would hit.
+    fn assert_round_trips(snapshot: &str, expected_tag: &str) -> serde_json::Value {
+        let value: serde_json::Value = serde_json::from_str(snapshot).unwrap();
+        assert!(
+            value.get(expected_tag).is_some(),
+            "snapshot is missing the `{expected_tag}` tag: {value}"
+        );
+        let reparsed: FractalParams = serde_json::from_str(snapshot).unwrap();
+        assert_eq!(value, serde_json::to_value(&reparsed).unwrap());
+        value
+    }
+
+    #[test]
+    fn mandelbrot_snapshot_json_round_trips() {
+        let json = r#"{"Mandelbrot":{"image_specification":{"resolution":[10,10],"center":[0,0],"width":1.0},"convergence_params":{"escape_radius_squared":4.0,"max_iter_count":50,"refinement_count":2},"color_map":{"color":{"background_color":[0,0,0],"color_maps":[[{"query":0.0,"rgb_raw":[0,255,0]},{"query":1.0,"rgb_raw":[255,0,0]}]]},"lookup_table_count":256,"histogram_bin_count":4},"render_options":{"sampling_level":1}}}"#;
+        let FractalParams::Mandelbrot(inner) = serde_json::from_str(json).unwrap() else {
+            panic!("expected Mandelbrot variant");
+        };
+        assert_round_trips(&mandelbrot_snapshot_json(&inner), "Mandelbrot");
+    }
+
+    #[test]
+    fn julia_snapshot_json_round_trips() {
+        let json = r#"{"Julia":{"image_specification":{"resolution":[10,10],"center":[0,0],"width":3.8},"constant_term":[-0.8,0.156],"convergence_params":{"escape_radius_squared":4.0,"max_iter_count":64,"refinement_count":2},"color_map":{"color":{"background_color":[14,14,14],"color_maps":[[{"query":0.0,"rgb_raw":[0,0,0]},{"query":1.0,"rgb_raw":[0,50,230]}]]},"lookup_table_count":256,"histogram_bin_count":4},"render_options":{"sampling_level":1}}}"#;
+        let FractalParams::Julia(inner) = serde_json::from_str(json).unwrap() else {
+            panic!("expected Julia variant");
+        };
+        assert_round_trips(&julia_snapshot_json(&inner), "Julia");
+    }
+
+    #[test]
+    fn ddp_snapshot_json_round_trips() {
+        let json = r#"{"DrivenDampedPendulum":{"image_specification":{"resolution":[10,10],"center":[0,0],"width":14.0},"time_phase":0.0,"n_max_period":50,"n_steps_per_period":12,"periodic_state_error_tolerance":0.05,"render_options":{"sampling_level":1},"color":{"background_color":[0,0,0],"color_maps":[[{"query":0.0,"rgb_raw":[255,255,255]},{"query":1.0,"rgb_raw":[255,255,255]}]]}}}"#;
+        let FractalParams::DrivenDampedPendulum(inner) = serde_json::from_str(json).unwrap() else {
+            panic!("expected DrivenDampedPendulum variant");
+        };
+        assert_round_trips(&ddp_snapshot_json(&inner), "DrivenDampedPendulum");
+    }
+
+    /// The Newton snapshot must re-inject the `system`, which is not part of
+    /// `CommonParams` (`Renderable::Params`). A missing system would fail to
+    /// deserialize; this also asserts the system content is preserved exactly.
+    #[test]
+    fn newton_snapshot_json_round_trips_and_preserves_system() {
+        let json = r#"{"NewtonsMethod":{"params":{"image_specification":{"resolution":[10,10],"center":[0,0],"width":5.0},"max_iteration_count":250,"convergence_tolerance":1e-6,"render_options":{"sampling_level":2},"color":{"background_color":[255,255,255],"color_maps":[[{"query":0.0,"rgb_raw":[9,42,27]},{"query":1.0,"rgb_raw":[0,0,0]}]]},"lookup_table_count":512,"histogram_bin_count":512},"system":{"RootsOfUnity":{"n_roots":4,"newton_step_size":1.0}}}}"#;
+        let FractalParams::NewtonsMethod(inner) = serde_json::from_str(json).unwrap() else {
+            panic!("expected NewtonsMethod variant");
+        };
+        let snapshot = newton_snapshot_json(&inner.system, &inner.params);
+        let value = assert_round_trips(&snapshot, "NewtonsMethod");
+        assert_eq!(
+            value["NewtonsMethod"]["system"],
+            serde_json::json!({ "RootsOfUnity": { "n_roots": 4, "newton_step_size": 1.0 } }),
+            "Newton snapshot dropped or altered the system"
         );
     }
 }

--- a/src/fractals/newtons_method.rs
+++ b/src/fractals/newtons_method.rs
@@ -13,6 +13,7 @@ use crate::core::{
     interactive,
     interpolation::ClampedLogInterpolator,
 };
+use crate::fractals::common::newton_snapshot_json;
 
 // Its often more efficient to compute both the value of a complex function
 // and its derivative (slope) at the same time.
@@ -354,10 +355,12 @@ pub fn render_newtons_method(
         SystemType::RootsOfUnity(system_params) => image_utils::render(
             NewtonsMethodRenderable::new(params.params.clone(), system_params.as_ref().clone()),
             file_prefix,
+            |p| newton_snapshot_json(&params.system, p),
         ),
         SystemType::CoshMinusOne(system_params) => image_utils::render(
             NewtonsMethodRenderable::new(params.params.clone(), system_params.as_ref().clone()),
             file_prefix,
+            |p| newton_snapshot_json(&params.system, p),
         ),
     }
 }
@@ -369,18 +372,22 @@ pub fn explore_fractal(
     match &params.system {
         SystemType::RootsOfUnity(system_params) => {
             file_prefix.create_and_step_into_sub_directory("roots_of_unity");
+            let system = params.system.clone();
             interactive::explore(
                 file_prefix,
                 params.params.image_specification,
                 NewtonsMethodRenderable::new(params.params.clone(), system_params.as_ref().clone()),
+                move |p| newton_snapshot_json(&system, p),
             )
         }
         SystemType::CoshMinusOne(system_params) => {
             file_prefix.create_and_step_into_sub_directory("cosh_minus_one");
+            let system = params.system.clone();
             interactive::explore(
                 file_prefix,
                 params.params.image_specification,
                 NewtonsMethodRenderable::new(params.params.clone(), system_params.as_ref().clone()),
+                move |p| newton_snapshot_json(&system, p),
             )
         }
     }

--- a/src/fractals/quadratic_map.rs
+++ b/src/fractals/quadratic_map.rs
@@ -173,9 +173,9 @@ pub trait QuadraticMapParams: Serialize + Clone + Debug + Sync + Send {
 
     /// Access the color map parameters.
     fn color_map_params(&self) -> &ColorMapParams;
-    /// Mutable access to the color map parameters. Used by the live editor
-    /// flow (Phase 7) to mutate keyframes through the renderer.
-    #[allow(dead_code)]
+    /// Mutable access to the color map parameters. Reached via
+    /// `Renderable::color_palette_mut` when the interactive render path syncs
+    /// the editor's edited palette into the renderer before a pass.
     fn color_map_params_mut(&mut self) -> &mut ColorMapParams;
 
     /// Access to the rendering options:


### PR DESCRIPTION
Make the "spacebar saves image" feature work properly - now you can trivially "close the loop" between exploring the fractal and rendering it at high resolution. Here is a quick example with the newton cosh minus one example:

<img width="1326" height="935" alt="image" src="https://github.com/user-attachments/assets/c1fa931b-b87c-4a31-bcaa-c435ce67099d" />

The interactive color picker makes it much easier to rapidly explore color space as well. Manually ran explore on all four supported fractal subtypes. Here is a screen shot from the explore of the julia set:

<img width="1025" height="423" alt="image" src="https://github.com/user-attachments/assets/710eb7ae-ba07-44c1-8154-482ea57ee18b" />

**Details**

This PR implements the “gated, restorable Space-as-save” workflow so interactive exploration can reliably produce a full-quality PNG plus a reloadable, tagged FractalParams JSON snapshot (matching the CLI render sidecar format). It also centralizes snapshot serialization so core stays independent of the fractals::FractalParams enum while still supporting Newton’s method (where the system must be re-injected).

**Changes:**

- Add a gated save state machine to the interactive render loop: Space triggers a forced full-quality render, locks interactive input, then writes a JSON snapshot + PNG.
- Introduce per-fractal snapshot JSON helpers that serialize a reloadable tagged FractalParams (including Newton’s system reinjection) and thread them through CLI render/explore and Newton dispatch.
- Refactor JSON/file writing utilities and reuse a shared ColorImage -> RGB8 conversion for PNG output.
